### PR TITLE
Switch to new recommended syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/filesystem": "^5.1"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^4.8|^5.0",
+        "phpunit/phpunit" : "^4.8 || ^5.0",
         "orchestra/testbench": "^3.2",
         "mockery/mockery": "~0.9.4"
     },


### PR DESCRIPTION
Composer now recommends using two `||` instead of a single `|`.