### PR TITLE
Update php version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": "^5.5.9 || ^7.0",
         "illuminate/support": "5.1.* || 5.2.*",
         "illuminate/console": "5.1.* || 5.2.*",
         "illuminate/filesystem": "5.1.* || 5.2.*"


### PR DESCRIPTION
We can be more specific with the PHP version instead of allowing all future versions.