### PR TITLE
Fix create new file

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -91,7 +91,7 @@ class Manager
         foreach ($this->languages() as $languageKey) {
             $file = $this->path."/{$languageKey}/{$fileName}.php";
             if (! $this->disk->exists($file)) {
-                file_put_contents($file, "<?php \n");
+                file_put_contents($file, "<?php \nreturn[\n];");
             }
         }
     }
@@ -119,11 +119,9 @@ class Manager
 
         foreach ($appends as $filePath => $values) {
             $fileContent = $this->getFileContent($filePath, true);
-
             $fileContent = array_map(function ($value) {
                 return addslashes($value);
             }, array_merge($fileContent, $values));
-
             $this->writeFile($filePath, $fileContent);
         }
     }


### PR DESCRIPTION
when i execute

```
php artisan langman:trans file.name
```

If file does not exist it returns

```
Language file file.php not found, would you like to create it? (yes/no) [no]:
```

then I type yes and the file gets created with content

```
<?php

```

then when I re-execute the command 

it asks me for the name key of each language. there is no problem here . but the problem is the new content of the file 

```
<?php

return [ 
    0 => 1,
   'name' => 'Name'
]

```

the reason of the first index 0 with value 1 is  getFileContent() Method 

```
return (array) include $filePath;
```

with empty file the content is '<?php \n' return 0 => 1 

so a change to the content of the new file stub should be

```
file_put_contents($filePath, "<?php\n\nreturn [];");
```
