### PR TITLE
Fixed issue when tests runs under windows

### DIFF
--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -33,6 +33,14 @@ class ManagerTest extends TestCase
 //            ],
         ];
 
+        if (stristr(PHP_OS, 'win') !== false) {
+            foreach ($expected as $keys => $value) {
+                foreach ($expected[$keys] as $key => $content) {
+                    $expected[$keys][$key] = str_replace('/', '\\', $content);
+                }
+            }
+        }
+
         $this->assertEquals($expected, $manager->files());
     }
 


### PR DESCRIPTION
Replace '/' for '\' when detect is running under windows.