### PR TITLE
Feature to get the missing keys for a specific languages 

### DIFF
--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -135,6 +135,7 @@ class MissingCommand extends Command
     /**
      * Get an array of keys that have missing values with a hint
      * from another language translation file if possible.
+     * also you can pass the languages needed to filter through
      *
      * ex: [ ['key' => 'product.color.nl', 'hint' => 'en = "color"'] ]
      *

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -135,7 +135,6 @@ class MissingCommand extends Command
     /**
      * Get an array of keys that have missing values with a hint
      * from another language translation file if possible.
-     * also you can pass the languages needed to filter through
      *
      * ex: [ ['key' => 'product.color.nl', 'hint' => 'en = "color"'] ]
      *
@@ -144,7 +143,7 @@ class MissingCommand extends Command
      */
     private function getMissing(array $languages)
     {
-        $files = $this->manager->files($languages);
+        $files = $this->manager->files();
 
         // Array of content of all files indexed by fileName.languageKey
         $filesResults = [];

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -144,7 +144,7 @@ class MissingCommand extends Command
      */
     private function getMissing(array $languages)
     {
-        $files = $this->manager->files();
+        $files = $this->manager->files($languages);
 
         // Array of content of all files indexed by fileName.languageKey
         $filesResults = [];

--- a/tests/MissingCommandTest.php
+++ b/tests/MissingCommandTest.php
@@ -94,11 +94,10 @@ class MissingCommandTest extends TestCase
         $this->artisan('langman:missing', ['--default' => true]);
     }
 
-
 	public function testAllowSeeTranslationInPassedTwoLanguages()
 	{
 		$manager = $this->app[Manager::class];
-		
+
 		$this->createTempFiles([
 			'en' => [
 				'user' => "<?php\n return ['name' => 'Name', 'age' => 'Age'];",

--- a/tests/MissingCommandTest.php
+++ b/tests/MissingCommandTest.php
@@ -93,4 +93,55 @@ class MissingCommandTest extends TestCase
 
         $this->artisan('langman:missing', ['--default' => true]);
     }
+
+
+	public function testAllowSeeTranslationInPassedTwoLanguages()
+	{
+		$manager = $this->app[Manager::class];
+		
+		$this->createTempFiles([
+			'en' => [
+				'user' => "<?php\n return ['name' => 'Name', 'age' => 'Age'];",
+			],
+			'nl' => [
+				'user' => "<?php\n return ['name' => 'Naam'];",
+			],
+			'es' => [
+				'user' => "<?php\n return ['name' => 'Nombre'];",
+			],
+
+		]);
+
+		$command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
+		$command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:nl<\/> translation/', null)->andReturn('fill_age');
+		$command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:es<\/> translation/', null)->andReturn('fill_age');
+
+		$this->app['artisan']->add($command);
+		$this->artisan('langman:missing', ['--lang' => 'nl,es']);
+	}
+
+
+	public function testAllowSeeTranslationInPassedOneLanguage()
+	{
+		$manager = $this->app[Manager::class];
+
+		$this->createTempFiles([
+			'en' => [
+				'user' => "<?php\n return ['name' => 'Name', 'age' => 'Age'];",
+			],
+			'nl' => [
+				'user' => "<?php\n return ['name' => 'Naam'];",
+			],
+			'es' => [
+				'user' => "<?php\n return ['name' => 'Nombre'];",
+			],
+
+		]);
+
+		$command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
+		$command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:nl<\/> translation/', null)->andReturn('fill_age');
+
+		$this->app['artisan']->add($command);
+		$this->artisan('langman:missing', ['--lang' => 'nl']);
+	}
 }


### PR DESCRIPTION
I think it would be great to add an option to the `missing` command to filter by a language like the following 

`php artisan langman:missing --lang=es`
or 
`php artisan langman:missing --lang=es,nl`

I added the missing parameters to the method so please review and tell me if something missing 

Thanks 