### PR TITLE
ignore strings with concatenated vars when syncing

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -309,7 +309,7 @@ class Manager
         $functions = ['trans', 'trans_choice', 'Lang::get', 'Lang::choice', 'Lang::trans', 'Lang::transChoice', '@lang', '@choice'];
 
         $pattern =
-            // See https://regex101.com/r/jS5fX0/3
+            // See https://regex101.com/r/jS5fX0/4
             '[^\w]'. // Must not start with any alphanum or _
             '(?<!->)'. // Must not start with ->
             '('.implode('|', $functions).')'.// Must start with one of the functions
@@ -317,7 +317,7 @@ class Manager
             "[\'\"]".// Match " or '
             '('.// Start a new group to match:
             '[a-zA-Z0-9_-]+'.// Must start with group
-            "([.][^\1)]+)+".// Be followed by one or more items/keys
+            "([.][^\1)$]+)+".// Be followed by one or more items/keys
             ')'.// Close group
             "[\'\"]".// Closing quote
             "[\),]"  // Close parentheses or new parameter


### PR DESCRIPTION
Although currently langman works properly (ignoring the match) when concatenating vars to the end of a the string like this:

`trans('app.line' . $ending_var)`

It doesn't support concatenating vars in the middle like this:

`trans('app.line' . $middle_var . '.ending_string')`

The last case inserts bad code in the lang file causing a parse error in PHP:

```php
'line' ' => [
    ' $middle_var ' => [
        ' '' => [
            'ending_string' => '',
        ],
    ],
],
```