### PR TITLE
feat:use base language translation as default value when syncing

### DIFF
--- a/config/langman.php
+++ b/config/langman.php
@@ -12,4 +12,17 @@ return [
      */
 
     'path' => realpath(base_path('resources/lang')),
+
+
+    /*
+     * --------------------------------------------------------------------------
+     * The base language for translation
+     * --------------------------------------------------------------------------
+     *
+     * This option is the base language,other languages should translate
+     * from base language, These language files are
+     * usually located in resources/lang but you may change that.
+     */
+
+    'base_language' => 'en',
 ];

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -101,10 +101,20 @@ class SyncCommand extends Command
      */
     private function fillMissingKeys($fileName, array $foundMissingKeys, $languageKey)
     {
+        // Get the base language translation
+        $baseLanguage = config('langman.base_language', 'en');
+        $baseLanguageFile = config('langman.path') . "/{$baseLanguage}/{$fileName}.php";
+        $baseTranslation = [];
+        if (file_exists($baseLanguageFile)) {
+            $baseTranslation = require $baseLanguageFile;
+        }
+
         $missingKeys = [];
 
         foreach ($foundMissingKeys as $missingKey) {
-            $missingKeys[$missingKey] = [$languageKey => ''];
+            // Use base language translation as default value
+            $languageValue = isset($baseTranslation[$missingKey]) ? $baseTranslation[$missingKey] : '';
+            $missingKeys[$missingKey] = [$languageKey => $languageValue];
 
             $this->output->writeln("\"<fg=yellow>{$fileName}.{$missingKey}.{$languageKey}</>\" was added.");
         }


### PR DESCRIPTION
Use base language's translation as default value,which can makes translate more convenience.