### PR TITLE
Fix rename command newKey check

### DIFF
--- a/src/Commands/RenameCommand.php
+++ b/src/Commands/RenameCommand.php
@@ -57,7 +57,9 @@ class RenameCommand extends Command
      */
     public function handle()
     {
-        $this->renameKey();
+        if (!$this->renameKey()) {
+            return ;
+        }
 
         $this->listFilesContainingOldKey();
 
@@ -103,6 +105,8 @@ class RenameCommand extends Command
             $file,
             [$newKey => $currentValues]
         );
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Hi @themsaid , 
In this PR i fixed the way of checking bad new key when using rename method.

Err example : 
```
$ php artisan langman:rename users.name users.username

Please provide the new key must not contain a dot.

The key at users.name was renamed to users.username successfully!
```

after this PR : 

```
$ php artisan langman:rename users.name users.username

Please provide the new key must not contain a dot.
```

Actually I don't know if my edition is optimal for this case .. but this is what i could handle at this moment.

Regards :)