### PR TITLE
Langman subdirectories

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -5,7 +5,6 @@ namespace Themsaid\Langman\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Themsaid\Langman\Manager;
-use Illuminate\Support\Str;
 
 class FindCommand extends Command
 {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -58,20 +58,21 @@ class Manager
         });
 
         $filesByFile = $files->groupBy(function ($file) {
-            $fileName = $file->getBasename('.'.$file->getExtension());
+            $filePath = str_replace('.' . $file->getExtension(), '', $file->getRelativePathname());
+            $filePath = array_reverse(explode('/', $filePath, 2))[0];
 
             if (Str::contains($file->getPath(), 'vendor')) {
-                $fileName = str_replace('.php', '', $file->getFileName());
+                $filePath = str_replace('.php', '', $file->getFileName());
 
                 $packageName = basename(dirname($file->getPath()));
 
-                return "{$packageName}::{$fileName}";
+                return "{$packageName}::{$filePath}";
             } else {
-                return $fileName;
+                return $filePath;
             }
         })->map(function ($files) {
             return $files->keyBy(function ($file) {
-                return basename($file->getPath());
+                return explode('/', str_replace($this->path, '', $file->getRelativePathname()))[0];
             })->map(function ($file) {
                 return $file->getRealPath();
             });


### PR DESCRIPTION
Make `laravel-langman` work with lang files in subdirectories:

```
lang
  |_ en
      |_something
         |_file.php
  |_ fr
      |_something
         |_file.php
```

The file parsing (https://github.com/themsaid/laravel-langman/compare/master...nicolasbeauvais:langman-subdirectories?expand=1#diff-e07e4dbec2b7af0db87b7c9a92ddee86R61) could be improved with the new `Str::before` and `Str::after` methods but it would require `illuminate/support:5.5` so I did it in a less fashionable way.

I renamed the `$fileName` var to `$filePath`  as it makes more sense now.

I only had to change two lines of code to make it work, you made some very steady code :+1: 