### PR TITLE
make 'show' command support for `langman:show foo/bar`

### DIFF
--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -147,7 +147,7 @@ class ShowCommand extends Command
     private function filesFromKey()
     {
         try {
-            if(Str::contains( $this->file, '/')) {
+            if (Str::contains( $this->file, '/')) {
                 return $this->manager->files()[explode('/', $this->file)[1]];// e.g. 'foo/bar' will return 'bar'
             }
             return $this->manager->files()[$this->file];

--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -147,6 +147,9 @@ class ShowCommand extends Command
     private function filesFromKey()
     {
         try {
+            if(Str::contains( $this->file, '/')) {
+                return $this->manager->files()[explode('/', $this->file)[1]];// e.g. 'foo/bar' will return 'bar'
+            }
             return $this->manager->files()[$this->file];
         } catch (\ErrorException $e) {
             $this->error(sprintf('Language file %s.php not found!', $this->file));

--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -147,7 +147,7 @@ class ShowCommand extends Command
     private function filesFromKey()
     {
         try {
-            if (Str::contains( $this->file, '/')) {
+            if (Str::contains($this->file, '/')) {
                 return $this->manager->files()[explode('/', $this->file)[1]];// e.g. 'foo/bar' will return 'bar'
             }
             return $this->manager->files()[$this->file];

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -71,7 +71,8 @@ class Manager
             }
         })->map(function ($files) {
             return $files->keyBy(function ($file) {
-                return basename($file->getPath());
+                $tmp = str_replace($this->path, '', $file->getRealPath());
+                return substr($tmp, 1, 2);// e.g. '/en/foo/bar.php' will return 'en'
             })->map(function ($file) {
                 return $file->getRealPath();
             });

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -38,6 +38,39 @@ class ManagerTest extends TestCase
         $this->assertEquals($expected, $manager->files());
     }
 
+    public function testFilesMethodWithNestedDirectory()
+    {
+        $manager = $this->app[\Themsaid\Langman\Manager::class];
+
+        $this->createTempFilesRecursive([
+            'en' => [
+                'foo' => [
+                    'user' => '',
+                    'category' => '']],
+            'nl' => [
+                'foo' => [
+                    'user' => '',
+                    'category' => '']],
+            'vendor' => [
+                'package' => [
+                    'en' => ['user' => '', 'product' => ''],
+                    'sp' => ['user' => '', 'product' => '']]],
+        ]);
+
+        $expected = [
+            'user' => [
+                'en' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'en'.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'user.php',
+                'nl' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'nl'.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'user.php',
+            ],
+            'category' => [
+                'en' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'en'.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'category.php',
+                'nl' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'nl'.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'category.php',
+            ],
+        ];
+
+        $this->assertEquals($expected, $manager->files());
+    }
+
     public function testLanguagesMethod()
     {
         $manager = $this->app[\Themsaid\Langman\Manager::class];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,6 +53,18 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
         }
     }
 
+    public function createTempFilesRecursive($files = [], $prefix = __DIR__.'/temp/')
+    {
+        foreach ($files as $file => $content) {
+            if (is_array($content)) {
+                mkdir($prefix.'/'.$file);
+                $this->createTempFilesRecursive($content, $prefix.'/'.$file.'/');
+            } else {
+                file_put_contents($prefix.'/'.$file.'.php', $content);
+            }
+        }
+    }
+
     public function resolveApplicationConsoleKernel($app)
     {
         $app->singleton('artisan', function ($app) {


### PR DESCRIPTION
In case we put translation file under nested folder e.g. lang/en/foo/bar.php
we must use foo/bar instead of foo.bar since there is some change in Laravel (not sure which version)