### PR TITLE
Do not throw exception when language file does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "illuminate/support": "~5.1",
-        "illuminate/console": "~5.1",
-        "illuminate/filesystem": "~5.1"
+        "illuminate/support": "~5.1 | ^6.0",
+        "illuminate/console": "~5.1 | ^6.0",
+        "illuminate/filesystem": "~5.1 | ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^4.8 || ^5.0",

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -112,7 +112,7 @@ class FindCommand extends Command
                 $original[$languageKey] =
                     isset($values[$languageKey])
                         ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                        : (isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '');
             }
 
             // Sort the language values based on language name

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -186,11 +186,15 @@ class Manager
         foreach ($this->languages() as $language) {
             $filePath = $this->path."/{$language}/{$fileName}.php";
 
-            $fileContent = $this->getFileContent($filePath);
+            try {
+                $fileContent = $this->getFileContent($filePath);
 
-            Arr::forget($fileContent, $key);
+                Arr::forget($fileContent, $key);
 
-            $this->writeFile($filePath, $fileContent);
+                $this->writeFile($filePath, $fileContent);
+            } catch (FileNotFoundException $e) {
+                // If there is no language file, continue
+            }
         }
     }
 


### PR DESCRIPTION
Calling `php artisan langman:remove key`, file not found exception is being thrown when there is no language file for the language.

Instead it should just continue to loop to the next language.