### PR TITLE
Create missing translation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ php artisan langman:sync
 This command will look into all files in `resources/views` and `app` and find all translation keys that are not covered in your translation files, after
 that it appends those keys to the files with a value equal to an empty string.
 
+### Create missing translation files from collected keys
+
+```
+php artisan langman:sync --create
+```
+
 ### Filling missing translations
 
 ```

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -13,7 +13,7 @@ class SyncCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'langman:sync';
+    protected $signature = 'langman:sync {--create : Create missing translation files}';
 
     /**
      * The description of the console command.
@@ -86,6 +86,21 @@ class SyncCommand extends Command
                     }
 
                     $this->fillMissingKeys($fileName, $missingKeys, $languageKey);
+                }
+            }
+        }
+
+        // create missing translation sections files from found keys.
+        if ($this->option('create') === 'true') {
+            $missingLangFiles = array_diff(
+                array_keys($allKeysInFiles),
+                array_keys($translationFiles)
+            );
+            foreach ($missingLangFiles as $langFile) {
+                foreach ($translationFiles as $fileName => $languages) {
+                    foreach ($languages as $languageKey => $path) {
+                        $this->fillMissingKeys($langFile, $allKeysInFiles[$langFile], $languageKey);
+                    }
                 }
             }
         }

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -91,7 +91,7 @@ class SyncCommand extends Command
         }
 
         // create missing translation sections files from found keys.
-        if ($this->option('create') === 'true') {
+        if ($this->option('create')) {
             $missingLangFiles = array_diff(
                 array_keys($allKeysInFiles),
                 array_keys($translationFiles)


### PR DESCRIPTION
Patches langman:sync by adding a --create option, when used, the section keys found in view files are then created in each language directory in case they're missing.