### PR TITLE
Adding parenthesis to extended ternary operator

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -111,8 +111,8 @@ class FindCommand extends Command
             foreach ($allLanguages as $languageKey) {
                 $original[$languageKey] =
                     (isset($values[$languageKey])
-                                             ? $values[$languageKey]
-                                             : isset($filesContent[$fileName][$languageKey][$key])) ? $filesContent[$fileName][$languageKey][$key] : '';
+                        ? $values[$languageKey]
+                        : isset($filesContent[$fileName][$languageKey][$key])) ? $filesContent[$fileName][$languageKey][$key] : '';
             }
 
             // Sort the language values based on language name

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -110,9 +110,9 @@ class FindCommand extends Command
 
             foreach ($allLanguages as $languageKey) {
                 $original[$languageKey] =
-                    isset($values[$languageKey])
-                        ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                    (isset($values[$languageKey])
+                                             ? $values[$languageKey]
+                                             : isset($filesContent[$fileName][$languageKey][$key])) ? $filesContent[$fileName][$languageKey][$key] : '';
             }
 
             // Sort the language values based on language name


### PR DESCRIPTION
PHP7.4: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`