### PR TITLE
[FIX] Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `…

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -109,10 +109,15 @@ class FindCommand extends Command
             $original = [];
 
             foreach ($allLanguages as $languageKey) {
-                $original[$languageKey] =
-                    isset($values[$languageKey])
-                        ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                if (isset($values[$languageKey])) {
+                    $original[$languageKey] = $values[$languageKey];
+                } else {
+                    if (isset($filesContent[$fileName][$languageKey][$key])) {
+                        $original[$languageKey] = $filesContent[$fileName][$languageKey][$key];
+                    } else {
+                        $original[$languageKey] = '';
+                    }
+                }
             }
 
             // Sort the language values based on language name


### PR DESCRIPTION
…(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`