### PR TITLE
Laravel 6-7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     ],
     "require": {
         "php": "^5.5.9 || ^7.0",
-        "illuminate/support": "~5.1",
-        "illuminate/console": "~5.1",
-        "illuminate/filesystem": "~5.1"
+        "illuminate/support": "~5.1 || ^6.0 || ^7.0",
+        "illuminate/console": "~5.1 || ^6.0 || ^7.0",
+        "illuminate/filesystem": "~5.1 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "^4.8 || ^5.0",

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -118,7 +118,11 @@ class FindCommand extends Command
             // Sort the language values based on language name
             ksort($original);
 
-            $output[$fullKey] = array_merge(['key' => "<fg=yellow>$fullKey</>"], $original);
+            $okey = $fullKey;
+            if($fileName == "-json") {
+              $okey = strlen($key) > 40 ? substr($key,0,36)." ..." : $key;
+            }
+            $output[$fullKey] = array_merge(['key' => "<fg=yellow>$okey</>"], $original);
         }
 
         return array_values($output);

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -120,7 +120,7 @@ class FindCommand extends Command
 
             $okey = $fullKey;
             if ($fileName == "-json") {
-              $okey = strlen($key) > 40 ? substr($key, 0, 36)." ..." : $key;
+                $okey = strlen($key) > 40 ? substr($key, 0, 36)." ..." : $key;
             }
             $output[$fullKey] = array_merge(['key' => "<fg=yellow>$okey</>"], $original);
         }

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -119,8 +119,8 @@ class FindCommand extends Command
             ksort($original);
 
             $okey = $fullKey;
-            if($fileName == "-json") {
-              $okey = strlen($key) > 40 ? substr($key,0,36)." ..." : $key;
+            if ($fileName == "-json") {
+              $okey = strlen($key) > 40 ? substr($key, 0, 36)." ..." : $key;
             }
             $output[$fullKey] = array_merge(['key' => "<fg=yellow>$okey</>"], $original);
         }

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -95,8 +95,12 @@ class MissingCommand extends Command
         $values = [];
 
         foreach ($missing as $missingKey) {
+            $key = $missingKey;
+            if(substr($key,0,6) == "-json.") {
+                $key = substr($key,6);
+            }
             $values[$missingKey] = $this->ask(
-                "<fg=yellow>{$missingKey}</> translation", $this->getDefaultValue($missingKey)
+               "<fg=yellow>{$key}</> translation", $this->getDefaultValue($missingKey)
             );
         }
 

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -96,8 +96,8 @@ class MissingCommand extends Command
 
         foreach ($missing as $missingKey) {
             $key = $missingKey;
-            if(substr($key,0,6) == "-json.") {
-                $key = substr($key,6);
+            if (substr($key, 0, 6) == "-json.") {
+                $key = substr($key, 6);
             }
             $values[$missingKey] = $this->ask(
                "<fg=yellow>{$key}</> translation", $this->getDefaultValue($missingKey)

--- a/src/Commands/RemoveCommand.php
+++ b/src/Commands/RemoveCommand.php
@@ -64,7 +64,7 @@ class RemoveCommand extends Command
         }
 
         $fileName=$file.".";
-        if($file === "-json") {
+        if ($file === "-json") {
             $fileName="";
         }
         if ($this->confirm("Are you sure you want to remove \"{$fileName}{$key}\"?")) {

--- a/src/Commands/RemoveCommand.php
+++ b/src/Commands/RemoveCommand.php
@@ -59,12 +59,15 @@ class RemoveCommand extends Command
         try {
             list($file, $key) = explode('.', $this->argument('key'), 2);
         } catch (\ErrorException $e) {
-            $this->error('Could not recognize the key you want to remove.');
-
-            return;
+            $file = "-json";
+            $key = $this->argument('key');
         }
 
-        if ($this->confirm("Are you sure you want to remove \"{$file}.{$key}\"?")) {
+        $fileName=$file.".";
+        if($file === "-json") {
+            $fileName="";
+        }
+        if ($this->confirm("Are you sure you want to remove \"{$fileName}{$key}\"?")) {
             if (Str::contains($file, '::')) {
                 try {
                     $parts = explode('::', $file);
@@ -81,7 +84,7 @@ class RemoveCommand extends Command
 
             $this->manager->removeKey($file, $key);
 
-            $this->info("{$file}.{$key} was removed successfully.");
+            $this->info("{$fileName}{$key} was removed successfully.");
         }
     }
 }

--- a/src/Commands/RenameCommand.php
+++ b/src/Commands/RenameCommand.php
@@ -74,7 +74,7 @@ class RenameCommand extends Command
         try {
             list($file, $key) = explode('.', $this->argument('oldKey'), 2);
         } catch (\ErrorException $e) {
-            $file="-json";
+            $file = "-json";
             $key = $this->argument('oldKey');
         }
 
@@ -84,7 +84,7 @@ class RenameCommand extends Command
         }
 
         $newKey = $this->argument('newKey');
-        if($file !== "-json") {
+        if ($file !== "-json") {
             $newKey = preg_replace('/(\w+)$/i', $newKey, $key);
         }
 

--- a/src/Commands/RenameCommand.php
+++ b/src/Commands/RenameCommand.php
@@ -61,7 +61,7 @@ class RenameCommand extends Command
 
         $this->listFilesContainingOldKey();
 
-        $this->info('The key at '.$this->argument('oldKey').' was renamed to '.$this->argument('newKey').' successfully!');
+        $this->info('The key at "'.$this->argument('oldKey').'" was renamed to "'.$this->argument('newKey').'" successfully!');
     }
 
     /**
@@ -74,18 +74,19 @@ class RenameCommand extends Command
         try {
             list($file, $key) = explode('.', $this->argument('oldKey'), 2);
         } catch (\ErrorException $e) {
-            $this->error('Could not recognize the key you want to rename.');
+            $file="-json";
+            $key = $this->argument('oldKey');
+        }
 
+        if (Str::contains($this->argument('newKey'), '.') && $file !== "-json") {
+            $this->error('The provided new key must not contain a dot.');
             return;
         }
 
-        if (Str::contains($this->argument('newKey'), '.')) {
-            $this->error('Please provide the new key must not contain a dot.');
-
-            return;
+        $newKey = $this->argument('newKey');
+        if($file !== "-json") {
+            $newKey = preg_replace('/(\w+)$/i', $newKey, $key);
         }
-
-        $newKey = preg_replace('/(\w+)$/i', $this->argument('newKey'), $key);
 
         $files = $this->manager->files()[$file];
 

--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -15,7 +15,7 @@ class ShowCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'langman:show {key} {--c|close} {--lang=}';
+    protected $signature = 'langman:show {key?} {--c|close} {--lang=} {--u|unused}';
 
     /**
      * The name and signature of the console command.
@@ -82,6 +82,15 @@ class ShowCommand extends Command
 
         $this->files = $this->filesFromKey();
 
+        $excluded = null;
+        if($this->option('unused')) {
+            $allKeysInFiles = $this->manager->collectFromFiles();
+            $keyfile = $this->file ?: "-json";
+            if(isset($allKeysInFiles[$keyfile])) {
+                $excluded = array_values($allKeysInFiles[$keyfile]);
+            }
+        }
+
         try {
             $this->languages = $this->getLanguages();
         } catch (InvalidArgumentException $e) {
@@ -90,18 +99,25 @@ class ShowCommand extends Command
             return;
         }
 
+        $displayFile = $this->file ?: "JSON strings";
+        $closematch = $this->key === null ? "" : ($this->option('close') ? 'using substring match' : 'using equality match');
+        $unused = $this->option('unused') ? 'unused keys' : 'keys';
+        $what = $this->key === null ? "all $unused" : "specific $unused matching '$this->key'";
+        $this->info("Displaying $what from $displayFile $closematch");
+
         $this->table(
             array_merge(['key'], $this->languages),
-            $this->tableRows()
+            $this->tableRows($excluded)
         );
     }
 
     /**
      * The output of the table rows.
      *
+     * @param $allKeysInFiles Array? if set, a list of all keys we should filter out
      * @return array
      */
-    private function tableRows()
+    private function tableRows($excluded)
     {
         $output = [];
 
@@ -109,11 +125,12 @@ class ShowCommand extends Command
 
         foreach ($this->files as $languageKey => $file) {
             foreach ($filesContent[$languageKey] = Arr::dot($this->manager->getFileContent($file)) as $key => $value) {
-                if (! $this->shouldShowKey($key)) {
+                if (! $this->shouldShowKey($key, $excluded)) {
                     continue;
                 }
 
-                $output[$key]['key'] = $key;
+                $okey = strlen($key) > 40 ? substr($key,0,36)." ..." : $key;
+                $output[$key]['key'] = $okey;
                 $output[$key][$languageKey] = $value ?: '';
             }
         }
@@ -133,7 +150,8 @@ class ShowCommand extends Command
             // Sort the language values based on language name
             ksort($original);
 
-            $output[$key] = array_merge(['key' => "<fg=yellow>$key</>"], $original);
+            $okey = strlen($key) > 40 ? substr($key,0,36)." ..." : $key;
+            $output[$key] = array_merge(['key' => "<fg=yellow>$okey</>"], $original);
         }
 
         return array_values($output);
@@ -147,9 +165,14 @@ class ShowCommand extends Command
     private function filesFromKey()
     {
         try {
-            return $this->manager->files()[$this->file];
+            return $this->manager->files()[$this->file ?? "-json"];
         } catch (\ErrorException $e) {
-            $this->error(sprintf('Language file %s.php not found!', $this->file));
+            if($this->file === NULL) {
+                $this->error(sprintf('JSON language strings not found!', $this->file));
+            }
+            else {
+                $this->error(sprintf('Language file %s.php not found!', $this->file));
+            }
 
             return [];
         }
@@ -162,22 +185,40 @@ class ShowCommand extends Command
      */
     private function parseKey()
     {
-        $parts = explode('.', $this->argument('key'), 2);
+        if(strlen($this->argument('key'))) {
+            $parts = explode('.', $this->argument('key'), 2);
 
-        $this->file = $parts[0];
+            $this->file = $parts[0];
 
-        $this->key = isset($parts[1]) ? $parts[1] : null;
+            $this->key = isset($parts[1]) ? $parts[1] : null;
 
-        if (Str::contains($this->file, '::')) {
-            try {
-                $parts = explode('::', $this->file);
+            if (Str::contains($this->file, '::')) {
+                try {
+                    $parts = explode('::', $this->file);
+                    $this->manager->setPathToVendorPackage($parts[0]);
+                } catch (\ErrorException $e) {
+                    $this->error('Could not recognize the package.');
 
-                $this->manager->setPathToVendorPackage($parts[0]);
-            } catch (\ErrorException $e) {
-                $this->error('Could not recognize the package.');
-
-                return;
+                    return;
+                }
             }
+            else {
+                if($this->key === null && !isset($this->manager->files()[$this->file])) {
+                    // fallback on a key search in the JSON strings
+                    $this->key = $this->file;
+                    $this->file = null;
+                }
+            }
+
+            // if we want to use --close on the JSON strings, the key is _always_ a key, even
+            // if it is also a file
+            if($this->key === null && $this->option('close')) {
+                $this->key = $this->file;
+                $this->file = null;
+            }
+        } else {
+            $this->file = null;
+            $this->key = null;
         }
     }
 
@@ -188,8 +229,12 @@ class ShowCommand extends Command
      *
      * @return bool
      */
-    private function shouldShowKey($key)
+    private function shouldShowKey($key, $exclude)
     {
+        if($exclude != null && in_array($key,$exclude)) {
+            return false;
+        }
+
         if ($this->key) {
             if (Str::contains($key, '.') && Str::startsWith($key, $this->key)) {
                 return true;

--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -167,7 +167,7 @@ class ShowCommand extends Command
         try {
             return $this->manager->files()[$this->file ?? "-json"];
         } catch (\ErrorException $e) {
-            if ($this->file === NULL) {
+            if ($this->file === null) {
                 $this->error(sprintf('JSON language strings not found!', $this->file));
             } else {
                 $this->error(sprintf('Language file %s.php not found!', $this->file));
@@ -229,7 +229,7 @@ class ShowCommand extends Command
      */
     private function shouldShowKey($key, $exclude)
     {
-        if ($exclude != null && in_array($key,$exclude)) {
+        if ($exclude != null && in_array($key, $exclude)) {
             return false;
         }
 

--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -83,10 +83,10 @@ class ShowCommand extends Command
         $this->files = $this->filesFromKey();
 
         $excluded = null;
-        if($this->option('unused')) {
+        if ($this->option('unused')) {
             $allKeysInFiles = $this->manager->collectFromFiles();
             $keyfile = $this->file ?: "-json";
-            if(isset($allKeysInFiles[$keyfile])) {
+            if (isset($allKeysInFiles[$keyfile])) {
                 $excluded = array_values($allKeysInFiles[$keyfile]);
             }
         }
@@ -129,7 +129,7 @@ class ShowCommand extends Command
                     continue;
                 }
 
-                $okey = strlen($key) > 40 ? substr($key,0,36)." ..." : $key;
+                $okey = strlen($key) > 40 ? substr($key, 0, 36)." ..." : $key;
                 $output[$key]['key'] = $okey;
                 $output[$key][$languageKey] = $value ?: '';
             }
@@ -150,7 +150,7 @@ class ShowCommand extends Command
             // Sort the language values based on language name
             ksort($original);
 
-            $okey = strlen($key) > 40 ? substr($key,0,36)." ..." : $key;
+            $okey = strlen($key) > 40 ? substr($key, 0, 36)." ..." : $key;
             $output[$key] = array_merge(['key' => "<fg=yellow>$okey</>"], $original);
         }
 
@@ -167,10 +167,9 @@ class ShowCommand extends Command
         try {
             return $this->manager->files()[$this->file ?? "-json"];
         } catch (\ErrorException $e) {
-            if($this->file === NULL) {
+            if ($this->file === NULL) {
                 $this->error(sprintf('JSON language strings not found!', $this->file));
-            }
-            else {
+            } else {
                 $this->error(sprintf('Language file %s.php not found!', $this->file));
             }
 
@@ -185,7 +184,7 @@ class ShowCommand extends Command
      */
     private function parseKey()
     {
-        if(strlen($this->argument('key'))) {
+        if (strlen($this->argument('key'))) {
             $parts = explode('.', $this->argument('key'), 2);
 
             $this->file = $parts[0];
@@ -201,9 +200,8 @@ class ShowCommand extends Command
 
                     return;
                 }
-            }
-            else {
-                if($this->key === null && !isset($this->manager->files()[$this->file])) {
+            } else {
+                if ($this->key === null && !isset($this->manager->files()[$this->file])) {
                     // fallback on a key search in the JSON strings
                     $this->key = $this->file;
                     $this->file = null;
@@ -212,7 +210,7 @@ class ShowCommand extends Command
 
             // if we want to use --close on the JSON strings, the key is _always_ a key, even
             // if it is also a file
-            if($this->key === null && $this->option('close')) {
+            if ($this->key === null && $this->option('close')) {
                 $this->key = $this->file;
                 $this->file = null;
             }
@@ -231,7 +229,7 @@ class ShowCommand extends Command
      */
     private function shouldShowKey($key, $exclude)
     {
-        if($exclude != null && in_array($key,$exclude)) {
+        if ($exclude != null && in_array($key,$exclude)) {
             return false;
         }
 

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -76,26 +76,24 @@ class SyncCommand extends Command
         $allKeysInFiles = $this->manager->collectFromFiles();
         $languages = $this->manager->languages();
 
-        foreach($allKeysInFiles as $file=>$labels) {
-            foreach($languages as $lang) {
-                if(!isset($translationFiles[$file])) {
-                    if($file === "-json") {
+        foreach ($allKeysInFiles as $file=>$labels) {
+            foreach ($languages as $lang) {
+                if (!isset($translationFiles[$file])) {
+                    if ($file === "-json") {
                         $this->info('Found json translation keys');
-                    }
-                    else {
+                    } else {
                         $this->info('Found translation keys for new file '.$file);
                     }
                     $translationFiles[$file]=[];
                 }
-                if(!isset($translationFiles[$file][$lang])) {
+                if (!isset($translationFiles[$file][$lang])) {
                     if($file === "-json") {
                         $this->info('Creating new JSON translation file for locale '.$lang);
-                    }
-                    else {
+                    } else {
                         $this->info('Creating new translation key file '.$file.' for locale '.$lang);
                     }
                     $this->manager->createFile($file, $lang);
-                    $translationFiles[$file][$lang]=$this->manager->createFileName($file,$lang);
+                    $translationFiles[$file][$lang]=$this->manager->createFileName($file, $lang);
                 }
 
                 $path = $translationFiles[$file][$lang];
@@ -130,10 +128,9 @@ class SyncCommand extends Command
         foreach ($foundMissingKeys as $missingKey) {
             $missingKeys[$missingKey] = [$languageKey => ''];
 
-            if($fileName == "-json") {
+            if ($fileName == "-json") {
                 $this->output->writeln("\"<fg=yellow>JSON {$languageKey}:{$missingKey}</>\" was added.");
-            }
-            else {
+            } else {
                 $this->output->writeln("\"<fg=yellow>{$languageKey}.{$fileName}.{$missingKey}</>\" was added.");
             }
         }

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -53,6 +53,9 @@ class SyncCommand extends Command
 
         $this->syncKeysFromFiles($translationFiles);
 
+        // reread the files in case we created new ones while syncing
+        $translationFiles = $this->manager->files();
+
         $this->syncKeysBetweenLanguages($translationFiles);
 
         $this->info('Done!');
@@ -71,22 +74,43 @@ class SyncCommand extends Command
 
         // An array of all translation keys as found in project files.
         $allKeysInFiles = $this->manager->collectFromFiles();
+        $languages = $this->manager->languages();
 
-        foreach ($translationFiles as $fileName => $languages) {
-            foreach ($languages as $languageKey => $path) {
+        foreach($allKeysInFiles as $file=>$labels) {
+            foreach($languages as $lang) {
+                if(!isset($translationFiles[$file])) {
+                    if($file === "-json") {
+                        $this->info('Found json translation keys');
+                    }
+                    else {
+                        $this->info('Found translation keys for new file '.$file);
+                    }
+                    $translationFiles[$file]=[];
+                }
+                if(!isset($translationFiles[$file][$lang])) {
+                    if($file === "-json") {
+                        $this->info('Creating new JSON translation file for locale '.$lang);
+                    }
+                    else {
+                        $this->info('Creating new translation key file '.$file.' for locale '.$lang);
+                    }
+                    $this->manager->createFile($file, $lang);
+                    $translationFiles[$file][$lang]=$this->manager->createFileName($file,$lang);
+                }
+
+                $path = $translationFiles[$file][$lang];
                 $fileContent = $this->manager->getFileContent($path);
 
-                if (isset($allKeysInFiles[$fileName])) {
-                    $missingKeys = array_diff($allKeysInFiles[$fileName], array_keys(array_dot($fileContent)));
+                $missingKeys = array_diff($labels, array_keys(Arr::dot($fileContent)));
 
-                    foreach ($missingKeys as $i => $missingKey) {
-                        if (Arr::has($fileContent, $missingKey)) {
-                            unset($missingKeys[$i]);
-                        }
+                // remove all keys that are in the translation, but not in any view
+                foreach ($missingKeys as $i => $missingKey) {
+                    if (Arr::has($fileContent, $missingKey)) {
+                        unset($missingKeys[$i]);
                     }
-
-                    $this->fillMissingKeys($fileName, $missingKeys, $languageKey);
                 }
+
+                $this->fillMissingKeys($file, $missingKeys, $lang);
             }
         }
     }
@@ -106,7 +130,12 @@ class SyncCommand extends Command
         foreach ($foundMissingKeys as $missingKey) {
             $missingKeys[$missingKey] = [$languageKey => ''];
 
-            $this->output->writeln("\"<fg=yellow>{$fileName}.{$missingKey}.{$languageKey}</>\" was added.");
+            if($fileName == "-json") {
+                $this->output->writeln("\"<fg=yellow>JSON {$languageKey}:{$missingKey}</>\" was added.");
+            }
+            else {
+                $this->output->writeln("\"<fg=yellow>{$languageKey}.{$fileName}.{$missingKey}</>\" was added.");
+            }
         }
 
         $this->manager->fillKeys(

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -87,7 +87,7 @@ class SyncCommand extends Command
                     $translationFiles[$file]=[];
                 }
                 if (!isset($translationFiles[$file][$lang])) {
-                    if($file === "-json") {
+                    if ($file === "-json") {
                         $this->info('Creating new JSON translation file for locale '.$lang);
                     } else {
                         $this->info('Creating new translation key file '.$file.' for locale '.$lang);

--- a/src/Commands/TransCommand.php
+++ b/src/Commands/TransCommand.php
@@ -110,11 +110,8 @@ class TransCommand extends Command
             $this->fileName = $matches[1];
             $this->key = $matches[2];
         } catch (\ErrorException $e) {
-            if (! $this->key) {
-                $this->error('Could not recognize the key you want to translate.');
-
-                return false;
-            }
+            $this->fileName = "-json";
+            $this->key = $this->argument('key');
         }
 
         if (Str::contains($this->fileName, '::')) {
@@ -144,8 +141,15 @@ class TransCommand extends Command
         try {
             return $this->manager->files()[$this->fileName];
         } catch (\ErrorException $e) {
-            if ($this->confirm(sprintf('Language file %s.php not found, would you like to create it?', $this->fileName))) {
-                $this->manager->createFile(str_replace($this->packageName.'::', '', $this->fileName));
+            if($this->fileName === "-json") {
+                if ($this->confirm(sprintf('JSON language file not found, would you like to create it?'))) {
+                    $this->manager->createFile($this->fileName);
+                }
+            }
+            else {
+                if ($this->confirm(sprintf('Language file %s.php not found, would you like to create it?', $this->fileName))) {
+                    $this->manager->createFile(str_replace($this->packageName.'::', '', $this->fileName));
+                }
             }
 
             return [];
@@ -180,7 +184,12 @@ class TransCommand extends Command
         );
 
         foreach ($values as $languageKey => $value) {
-            $this->line("<fg=yellow>{$this->fileName}.{$this->key}:{$languageKey}</> was set to \"<fg=yellow>{$value}</>\" successfully.");
+            if($this->fileName == "-json") {
+                $this->line("<fg=yellow>JSON {$this->key}:{$languageKey}</> was set to \"<fg=yellow>{$value}</>\" successfully.");
+            }
+            else {
+                $this->line("<fg=yellow>{$this->fileName}.{$this->key}:{$languageKey}</> was set to \"<fg=yellow>{$value}</>\" successfully.");
+            }
         }
     }
 
@@ -197,10 +206,14 @@ class TransCommand extends Command
         foreach ($languages as $languageKey) {
             $languageContent = $this->manager->getFileContent($this->files[$languageKey]);
 
+            $promptFile=$this->fileName.".";
+            if($this->fileName == "-json") {
+                $promptFile="";
+            }
             $values[$languageKey] = $this->ask(
                 sprintf(
-                    '<fg=yellow>%s.%s:%s</> translation',
-                    $this->fileName,
+                    '<fg=yellow>%s%s:%s</> translation',
+                    $promptFile,
                     $this->key,
                     $languageKey
                 ),

--- a/src/Commands/TransCommand.php
+++ b/src/Commands/TransCommand.php
@@ -141,12 +141,11 @@ class TransCommand extends Command
         try {
             return $this->manager->files()[$this->fileName];
         } catch (\ErrorException $e) {
-            if($this->fileName === "-json") {
+            if ($this->fileName === "-json") {
                 if ($this->confirm(sprintf('JSON language file not found, would you like to create it?'))) {
                     $this->manager->createFile($this->fileName);
                 }
-            }
-            else {
+            } else {
                 if ($this->confirm(sprintf('Language file %s.php not found, would you like to create it?', $this->fileName))) {
                     $this->manager->createFile(str_replace($this->packageName.'::', '', $this->fileName));
                 }
@@ -184,10 +183,9 @@ class TransCommand extends Command
         );
 
         foreach ($values as $languageKey => $value) {
-            if($this->fileName == "-json") {
+            if ($this->fileName == "-json") {
                 $this->line("<fg=yellow>JSON {$this->key}:{$languageKey}</> was set to \"<fg=yellow>{$value}</>\" successfully.");
-            }
-            else {
+            } else {
                 $this->line("<fg=yellow>{$this->fileName}.{$this->key}:{$languageKey}</> was set to \"<fg=yellow>{$value}</>\" successfully.");
             }
         }
@@ -206,9 +204,9 @@ class TransCommand extends Command
         foreach ($languages as $languageKey) {
             $languageContent = $this->manager->getFileContent($this->files[$languageKey]);
 
-            $promptFile=$this->fileName.".";
-            if($this->fileName == "-json") {
-                $promptFile="";
+            $promptFile = $this->fileName.".";
+            if ($this->fileName == "-json") {
+                $promptFile = "";
             }
             $values[$languageKey] = $this->ask(
                 sprintf(

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -54,23 +54,28 @@ class Manager
     public function files()
     {
         $files = Collection::make($this->disk->allFiles($this->path))->filter(function ($file) {
-            return $this->disk->extension($file) == 'php';
+            return $this->disk->extension($file) == 'php' || $this->disk->extension($file) == 'json';
         });
 
         $filesByFile = $files->groupBy(function ($file) {
             $fileName = $file->getBasename('.'.$file->getExtension());
 
             if (Str::contains($file->getPath(), 'vendor')) {
-                $fileName = str_replace('.php', '', $file->getFileName());
-
                 $packageName = basename(dirname($file->getPath()));
-
                 return "{$packageName}::{$fileName}";
             } else {
-                return $fileName;
+                // for our locale-general JSON files, group them as '-json'
+                if($file->getExtension() == "json") {
+                    return "-json";
+                } else {
+                    return $fileName;
+                }
             }
         })->map(function ($files) {
             return $files->keyBy(function ($file) {
+                if($file->getExtension() == "json") {
+                    return $file->getBasename('.json');
+                }
                 return basename($file->getPath());
             })->map(function ($file) {
                 return $file->getRealPath();
@@ -131,16 +136,50 @@ class Manager
     /**
      * Create a file for all languages if does not exist already.
      *
-     * @param $fileName
+     * @param $fileName     
+     * @param $lang string|Array    locale or array of locales to create files for
      * @return void
+     *
+     * If $lang is not passed, create files in all locales
+     * @return file path of the created file
      */
-    public function createFile($fileName)
+    public function createFile($fileName, $lang=null)
     {
-        foreach ($this->languages() as $languageKey) {
-            $file = $this->path."/{$languageKey}/{$fileName}.php";
+        if($lang===null) {
+            $lang=$this->languages();
+        }
+        else if(!is_array($lang)) {
+            $lang=[$lang];
+        }
+
+        $file=null;
+        foreach ($lang as $languageKey) {
+            $file = $this->createFileName($fileName, $languageKey);
             if (! $this->disk->exists($file)) {
-                file_put_contents($file, "<?php \n\n return[];");
+                if($fileName === "-json") {
+                    file_put_contents($file, json_encode([]));
+                }
+                else {
+                    file_put_contents($file, "<?php \n\n return[];");
+                }
             }
+        }
+    }
+
+    /**
+     * Construct a filename based on a module and a languageKey
+     *
+     * @param $file string module name or "-json" for JSON strings
+     * @param $languageKey string language locale
+     *
+     * @returns string file path
+     */
+    public function createFileName($file, $languageKey) {
+        if($file === "-json") {
+            return $this->path . "/{$languageKey}.json";
+        }
+        else {
+            return $this->path."/{$languageKey}/{$file}.php";
         }
     }
 
@@ -159,9 +198,8 @@ class Manager
 
         foreach ($keys as $key => $values) {
             foreach ($values as $languageKey => $value) {
-                $filePath = $this->path."/{$languageKey}/{$fileName}.php";
-
-                Arr::set($appends[$filePath], $key, $value);
+                $filePath = $this->createFileName($fileName, $languageKey);
+                Arr::set($appends[$filePath],$key,$value);
             }
         }
 
@@ -184,7 +222,7 @@ class Manager
     public function removeKey($fileName, $key)
     {
         foreach ($this->languages() as $language) {
-            $filePath = $this->path."/{$language}/{$fileName}.php";
+            $filePath = $this->createFileName($fileName, $language);
 
             $fileContent = $this->getFileContent($filePath);
 
@@ -203,11 +241,16 @@ class Manager
      */
     public function writeFile($filePath, array $translations)
     {
-        $content = "<?php \n\nreturn [";
+        $ext = substr(strrchr($filePath,'.'),1);
+        ksort($translations);
 
-        $content .= $this->stringLineMaker($translations);
-
-        $content .= "\n];";
+        if($ext == "php") {
+            $content = "<?php \n\nreturn [";
+            $content .= $this->stringLineMaker($translations);
+            $content .= "\n];";
+        } else {
+            $content = json_encode($translations, JSON_PRETTY_PRINT);
+        }
 
         file_put_contents($filePath, $content);
     }
@@ -247,18 +290,32 @@ class Manager
      */
     public function getFileContent($filePath, $createIfNotExists = false)
     {
+        $info = pathinfo($filePath);
         if ($createIfNotExists && ! $this->disk->exists($filePath)) {
             if (! $this->disk->exists($directory = dirname($filePath))) {
                 mkdir($directory, 0777, true);
             }
 
-            file_put_contents($filePath, "<?php\n\nreturn [];");
+            if($info['extension'] == 'php') {
+                file_put_contents($filePath, "<?php\n\nreturn [];\r\n");
+            }
+            if($info['extension'] == 'json') {
+                file_put_contents($filePath, "{\r\n}\r\n");
+            }
 
             return [];
         }
 
         try {
-            return (array) include $filePath;
+            if($info['extension'] == 'php') {
+                return (array) include $filePath;
+            } else {
+                $retval = json_decode(file_get_contents($filePath),TRUE);
+                if($retval === FALSE || empty($retval)) {
+                    $retval = [];
+                }
+                return $retval;
+            }
         } catch (\ErrorException $e) {
             throw new FileNotFoundException('File not found: '.$filePath);
         }
@@ -269,6 +326,7 @@ class Manager
      *
      * e.g. ['users' => ['city', 'name', 'phone']]
      *
+     * @param Array $files ['user' => ['en' => 'user.php', 'nl' => 'user.php'], 'password' => ...]
      * @return array
      */
     public function collectFromFiles()
@@ -277,20 +335,32 @@ class Manager
 
         foreach ($this->getAllViewFilesWithTranslations() as $file => $matches) {
             foreach ($matches as $key) {
-                try {
-                    list($fileName, $keyName) = explode('.', $key, 2);
-                } catch (\ErrorException $e) {
-                    continue;
-                }
+                $fileName="-json";
+                $keyName=$key;
 
+                if(strpos($key,'.')!==FALSE)
+                {
+                    list($fileName, $keyName) = explode('.', $key, 2);
+
+                    if(!isset($translationKeys[$fileName])) {
+                        // only create a new file if the fileName contains only alnum characters
+                        if(preg_match("/^[a-zA-Z][a-zA-Z0-9]*\$/",$fileName)) {
+                            $translationKeys[$fileName]=[];
+                        }
+                        else {
+                            $fileName="-json";
+                            $keyName=$key;
+                        }
+                    }
+                }
                 if (isset($translationKeys[$fileName]) && in_array($keyName, $translationKeys[$fileName])) {
+                    // translation already found
                     continue;
                 }
 
                 $translationKeys[$fileName][] = $keyName;
             }
         }
-
         return $translationKeys;
     }
 
@@ -312,17 +382,15 @@ class Manager
 
         $pattern =
             // See https://regex101.com/r/jS5fX0/4
-            '[^\w]'. // Must not start with any alphanum or _
-            '(?<!->)'. // Must not start with ->
+            // https://regex101.com/r/L9maxG/3
+            '[^\w]'.                         // Must not start with any alphanum or _
+            '(?<!->)'.                       // Must not start with ->
             '('.implode('|', $functions).')'.// Must start with one of the functions
-            "\(".// Match opening parentheses
-            "[\'\"]".// Match " or '
-            '('.// Start a new group to match:
-            '[a-zA-Z0-9_-]+'.// Must start with group
-            "([.][^\1)$]+)+".// Be followed by one or more items/keys
-            ')'.// Close group
-            "[\'\"]".// Closing quote
-            "[\),]"  // Close parentheses or new parameter
+            '\s*\(\s*'.                      // match opening parentheses using any number of whitespace
+            "((?<![\\\\])['\"])".               // match an unescaped opening quote
+            '((?:.(?!(?<![\\\\])\2))*.?)'.     // match everything until we find the same, unescaped quote
+            '\2'.                            // match the closing quote
+            '\s*[,\)]'                       // match a following comma or closing parentheses
         ;
 
         $allMatches = [];
@@ -330,7 +398,7 @@ class Manager
         /** @var \Symfony\Component\Finder\SplFileInfo $file */
         foreach ($this->disk->allFiles($this->syncPaths) as $file) {
             if (preg_match_all("/$pattern/siU", $file->getContents(), $matches)) {
-                $allMatches[$file->getRelativePathname()] = $matches[2];
+                $allMatches[$file->getRelativePathname()] = $matches[3];
             }
         }
 
@@ -371,15 +439,20 @@ class Manager
         // other languages. Those keys combined with ones with values = ''
         // will be sent to the console user to fill and save in disk.
         foreach ($values as $key => $value) {
-            list($fileName, $languageKey, $key) = explode('.', $key, 3);
+            $parts = explode('.', $key, 3);
+            $fileName = $parts[0];
+            $languageKey = $parts[1];
+            if(sizeof($parts)>2) {
+                $key = $parts[2];
 
-            if (in_array("{$fileName}.{$key}", $searched)) {
-                continue;
-            }
+                if (in_array("{$fileName}.{$key}", $searched)) {
+                    continue;
+                }
 
-            foreach ($this->languages() as $languageName) {
-                if (! Arr::has($values, "{$fileName}.{$languageName}.{$key}") && ! array_key_exists("{$fileName}.{$languageName}.{$key}", $values)) {
-                    $missing[] = "{$fileName}.{$key}:{$languageName}";
+                foreach ($this->languages() as $languageName) {
+                    if (! Arr::has($values, "{$fileName}.{$languageName}.{$key}") && ! array_key_exists("{$fileName}.{$languageName}.{$key}", $values)) {
+                        $missing[] = "{$fileName}.{$key}:{$languageName}";
+                    }
                 }
             }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -147,7 +147,7 @@ class Manager
     {
         if ($lang === null) {
             $lang=$this->languages();
-        } else if (!is_array($lang)) {
+        } elseif (!is_array($lang)) {
             $lang=[$lang];
         }
 
@@ -172,7 +172,7 @@ class Manager
      *
      * @returns string file path
      */
-    public function createFileName($file, $languageKey) 
+    public function createFileName($file, $languageKey)
     {
         if ($file === "-json") {
             return $this->path . "/{$languageKey}.json";
@@ -308,7 +308,7 @@ class Manager
             if ($info['extension'] == 'php') {
                 return (array) include $filePath;
             } else {
-                $retval = json_decode(file_get_contents($filePath), TRUE);
+                $retval = json_decode(file_get_contents($filePath), true);
                 if ($retval === false || empty($retval)) {
                     $retval = [];
                 }
@@ -336,7 +336,7 @@ class Manager
                 $fileName = "-json";
                 $keyName = $key;
 
-                if (strpos($key,'.') !== false)
+                if (strpos($key, '.') !== false)
                 {
                     list($fileName, $keyName) = explode('.', $key, 2);
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -336,8 +336,7 @@ class Manager
                 $fileName = "-json";
                 $keyName = $key;
 
-                if (strpos($key, '.') !== false)
-                {
+                if (strpos($key, '.') !== false) {
                     list($fileName, $keyName) = explode('.', $key, 2);
 
                     if (!isset($translationKeys[$fileName])) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -65,7 +65,7 @@ class Manager
                 return "{$packageName}::{$fileName}";
             } else {
                 // for our locale-general JSON files, group them as '-json'
-                if($file->getExtension() == "json") {
+                if ($file->getExtension() == "json") {
                     return "-json";
                 } else {
                     return $fileName;
@@ -73,7 +73,7 @@ class Manager
             }
         })->map(function ($files) {
             return $files->keyBy(function ($file) {
-                if($file->getExtension() == "json") {
+                if ($file->getExtension() == "json") {
                     return $file->getBasename('.json');
                 }
                 return basename($file->getPath());
@@ -136,7 +136,7 @@ class Manager
     /**
      * Create a file for all languages if does not exist already.
      *
-     * @param $fileName     
+     * @param $fileName
      * @param $lang string|Array    locale or array of locales to create files for
      * @return void
      *
@@ -145,10 +145,9 @@ class Manager
      */
     public function createFile($fileName, $lang=null)
     {
-        if($lang===null) {
+        if ($lang === null) {
             $lang=$this->languages();
-        }
-        else if(!is_array($lang)) {
+        } else if (!is_array($lang)) {
             $lang=[$lang];
         }
 
@@ -156,10 +155,9 @@ class Manager
         foreach ($lang as $languageKey) {
             $file = $this->createFileName($fileName, $languageKey);
             if (! $this->disk->exists($file)) {
-                if($fileName === "-json") {
+                if ($fileName === "-json") {
                     file_put_contents($file, json_encode([]));
-                }
-                else {
+                } else {
                     file_put_contents($file, "<?php \n\n return[];");
                 }
             }
@@ -174,11 +172,11 @@ class Manager
      *
      * @returns string file path
      */
-    public function createFileName($file, $languageKey) {
-        if($file === "-json") {
+    public function createFileName($file, $languageKey) 
+    {
+        if ($file === "-json") {
             return $this->path . "/{$languageKey}.json";
-        }
-        else {
+        } else {
             return $this->path."/{$languageKey}/{$file}.php";
         }
     }
@@ -199,7 +197,7 @@ class Manager
         foreach ($keys as $key => $values) {
             foreach ($values as $languageKey => $value) {
                 $filePath = $this->createFileName($fileName, $languageKey);
-                Arr::set($appends[$filePath],$key,$value);
+                Arr::set($appends[$filePath], $key, $value);
             }
         }
 
@@ -241,10 +239,10 @@ class Manager
      */
     public function writeFile($filePath, array $translations)
     {
-        $ext = substr(strrchr($filePath,'.'),1);
+        $ext = substr(strrchr($filePath, '.'), 1);
         ksort($translations);
 
-        if($ext == "php") {
+        if ($ext == "php") {
             $content = "<?php \n\nreturn [";
             $content .= $this->stringLineMaker($translations);
             $content .= "\n];";
@@ -296,10 +294,10 @@ class Manager
                 mkdir($directory, 0777, true);
             }
 
-            if($info['extension'] == 'php') {
+            if ($info['extension'] == 'php') {
                 file_put_contents($filePath, "<?php\n\nreturn [];\r\n");
             }
-            if($info['extension'] == 'json') {
+            if ($info['extension'] == 'json') {
                 file_put_contents($filePath, "{\r\n}\r\n");
             }
 
@@ -307,11 +305,11 @@ class Manager
         }
 
         try {
-            if($info['extension'] == 'php') {
+            if ($info['extension'] == 'php') {
                 return (array) include $filePath;
             } else {
-                $retval = json_decode(file_get_contents($filePath),TRUE);
-                if($retval === FALSE || empty($retval)) {
+                $retval = json_decode(file_get_contents($filePath), TRUE);
+                if ($retval === false || empty($retval)) {
                     $retval = [];
                 }
                 return $retval;
@@ -335,21 +333,20 @@ class Manager
 
         foreach ($this->getAllViewFilesWithTranslations() as $file => $matches) {
             foreach ($matches as $key) {
-                $fileName="-json";
-                $keyName=$key;
+                $fileName = "-json";
+                $keyName = $key;
 
-                if(strpos($key,'.')!==FALSE)
+                if (strpos($key,'.') !== false)
                 {
                     list($fileName, $keyName) = explode('.', $key, 2);
 
-                    if(!isset($translationKeys[$fileName])) {
+                    if (!isset($translationKeys[$fileName])) {
                         // only create a new file if the fileName contains only alnum characters
-                        if(preg_match("/^[a-zA-Z][a-zA-Z0-9]*\$/",$fileName)) {
-                            $translationKeys[$fileName]=[];
-                        }
-                        else {
-                            $fileName="-json";
-                            $keyName=$key;
+                        if (preg_match("/^[a-zA-Z][a-zA-Z0-9]*\$/", $fileName)) {
+                            $translationKeys[$fileName] = [];
+                        } else {
+                            $fileName = "-json";
+                            $keyName = $key;
                         }
                     }
                 }
@@ -442,7 +439,7 @@ class Manager
             $parts = explode('.', $key, 3);
             $fileName = $parts[0];
             $languageKey = $parts[1];
-            if(sizeof($parts)>2) {
+            if (sizeof($parts) > 2) {
                 $key = $parts[2];
 
                 if (in_array("{$fileName}.{$key}", $searched)) {

--- a/tests/FindCommandTest.php
+++ b/tests/FindCommandTest.php
@@ -10,8 +10,7 @@ class FindCommandTest extends TestCase
         $this->createTempFiles();
 
         $this->artisan('langman:find', ['keyword' => 'ragnar']);
-
-        $this->assertContains('No language files were found!', $this->consoleOutput());
+        $this->assertStringContainsString('No language files were found!', $this->consoleOutput());
     }
 
     public function testCommandOutputForFile()
@@ -26,8 +25,8 @@ class FindCommandTest extends TestCase
 
         $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
         $this->assertRegExp('/user\.not_found(?:.*)User NoT fOunD(?:.*)something/', $this->consoleOutput());
-        $this->assertNotContains('age', $this->consoleOutput());
-        $this->assertNotContains('else', $this->consoleOutput());
+        $this->assertStringNotContainsString('age', $this->consoleOutput());
+        $this->assertStringNotContainsString('else', $this->consoleOutput());
     }
 
     public function testCommandOutputForFileWithNestedKeys()
@@ -41,7 +40,7 @@ class FindCommandTest extends TestCase
 
         $this->assertRegExp('/key(?:.*)en(?:.*)sp/', $this->consoleOutput());
         $this->assertRegExp('/user\.missing\.not_found(?:.*)user not found(?:.*)sp/', $this->consoleOutput());
-        $this->assertNotContains('jarl_borg', $this->consoleOutput());
+        $this->assertStringNotContainsString('jarl_borg', $this->consoleOutput());
     }
 
     public function testCommandOutputForPackage()
@@ -56,6 +55,21 @@ class FindCommandTest extends TestCase
 
         $this->assertRegExp('/key(?:.*)en(?:.*)sp/', $this->consoleOutput());
         $this->assertRegExp('/package::file\.not_found(?:.*)file not found here(?:.*)something/', $this->consoleOutput());
-        $this->assertNotContains('weight', $this->consoleOutput());
+        $this->assertStringNotContainsString('weight', $this->consoleOutput());
+    }
+
+    public function testCommandOutputForJson()
+    {
+        $this->createTempFiles([
+            'en' => ['-json' => ['String1' => 'Usor','String2'=>'Admin'] ],
+            'nl' => ['-json' => ['String1' => 'Giraffe','String2'=>'Tiger'] ],
+        ]);
+
+        $this->artisan('langman:find', ['keyword' => 'admin']);
+
+        $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
+        $this->assertRegExp('/^| String2 (?:.*)Admin(?:.*)Tiger/', $this->consoleOutput());
+        $this->assertStringNotContainsString('User', $this->consoleOutput());
+        $this->assertStringNotContainsString('Giraffe', $this->consoleOutput());
     }
 }

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -25,7 +25,7 @@ class Kernel extends \Illuminate\Foundation\Console\Kernel
      *
      * @throws \Exception
      */
-    protected function reportException(Exception $e)
+    protected function reportException(Throwable $e)
     {
         throw $e;
     }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -75,13 +75,13 @@ class ManagerTest extends TestCase
         $this->assertEquals([], (array) include $this->app['config']['langman.path'].'/en/user.php');
         $this->assertEquals([], (array) include $this->app['config']['langman.path'].'/sp/user.php');
 
-        $manager->createFile('-json',"sp");
+        $manager->createFile('-json', "sp");
 
         $this->assertFileExists($this->app['config']['langman.path'].'/en.json');
         $this->assertFileExists($this->app['config']['langman.path'].'/sp.json');
         $this->assertFileNotExists($this->app['config']['langman.path'].'/nl.json');
-        $this->assertEquals([], (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE));
-        $this->assertEquals([], (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/sp.json'), TRUE));
+        $this->assertEquals([], (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), true));
+        $this->assertEquals([], (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/sp.json'), true));
     }
 
     public function testWriteFile()

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -10,8 +10,8 @@ class ManagerTest extends TestCase
         $manager = $this->app[\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
-            'en' => ['user' => '', 'category' => ''],
-            'nl' => ['user' => '', 'category' => ''],
+            'en' => ['user' => '', 'category' => '', "-json"=>[]],
+            'nl' => ['user' => '', 'category' => '', "-json"=>[]],
             'vendor' => ['package' => ['en' => ['user' => '', 'product' => ''], 'sp' => ['user' => '', 'product' => '']]],
         ]);
 
@@ -24,6 +24,10 @@ class ManagerTest extends TestCase
                 'en' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'en'.DIRECTORY_SEPARATOR.'category.php',
                 'nl' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'nl'.DIRECTORY_SEPARATOR.'category.php',
             ],
+            "-json" => [
+                'en' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'en.json',
+                'nl' => __DIR__.DIRECTORY_SEPARATOR.'temp'.DIRECTORY_SEPARATOR.'nl.json',
+            ]
 // Uncomment when starting to support vendor language files
 //            'package::product' => [
 //                'en' => __DIR__.'/temp/vendor/package/en/product.php',
@@ -56,7 +60,7 @@ class ManagerTest extends TestCase
         $manager = $this->app[\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
-            'en' => [],
+            'en' => ["-json"=>[]],
             'sp' => [],
             'nl' => ['user' => '__UN_TOUCHED__'],
         ]);
@@ -65,8 +69,19 @@ class ManagerTest extends TestCase
 
         $this->assertFileExists($this->app['config']['langman.path'].'/en/user.php');
         $this->assertFileExists($this->app['config']['langman.path'].'/sp/user.php');
+        $this->assertFileNotExists($this->app['config']['langman.path'].'/sp.json');
+        $this->assertFileNotExists($this->app['config']['langman.path'].'/nl.json');
         $this->assertEquals('__UN_TOUCHED__', file_get_contents($this->app['config']['langman.path'].'/nl/user.php'));
         $this->assertEquals([], (array) include $this->app['config']['langman.path'].'/en/user.php');
+        $this->assertEquals([], (array) include $this->app['config']['langman.path'].'/sp/user.php');
+
+        $manager->createFile('-json',"sp");
+
+        $this->assertFileExists($this->app['config']['langman.path'].'/en.json');
+        $this->assertFileExists($this->app['config']['langman.path'].'/sp.json');
+        $this->assertFileNotExists($this->app['config']['langman.path'].'/nl.json');
+        $this->assertEquals([], (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE));
+        $this->assertEquals([], (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/sp.json'), TRUE));
     }
 
     public function testWriteFile()
@@ -92,22 +107,44 @@ class ManagerTest extends TestCase
         $this->assertEquals($values, (array) include $filePath);
     }
 
-    public function testGetFileContentReadsContent()
+    public function testWriteJSONFile()
     {
         $manager = $this->app[\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
-            'en' => ['users' => "<?php return ['_content_'];"],
+            'en' => ["-json" => []],
+            'nl' => ["-json" => []],
+        ]);
+
+        $filePath = $this->app['config']['langman.path'].'/en.json';
+
+        $values = [
+            'name' => ['first' => 'first', 'last' => ['last1' => '1', 'last2' => 2]],
+            'age' => 'age',
+            'double_quotes' => '"with quotes"',
+            'quotes' => "With some ' quotes",
+        ];
+
+        $manager->writeFile($filePath, $values);
+
+        $this->assertEquals($values, $manager->getFileContent($filePath));
+    }
+
+    public function testGetFileContentReadsContent()
+    {
+        $manager = $this->app[\Themsaid\Langman\Manager::class];
+
+        $values = ["Test1"=>"Value1", 'Test2'=>'Value2'];
+        $this->createTempFiles([
+            'en' => ['users' => "<?php return ['_content_'];", "-json"=>$values],
         ]);
 
         $filePath = $this->app['config']['langman.path'].'/en/users.php';
 
         $this->assertContains('_content_', $manager->getFileContent($filePath));
+        $this->assertEquals($values, $manager->getFileContent($this->app['config']['langman.path'].'/en.json'));
     }
 
-    /**
-     * @expectedException Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
     public function testGetFileContentThrowsExceptionIfNotFound()
     {
         $manager = $this->app[\Themsaid\Langman\Manager::class];
@@ -116,6 +153,7 @@ class ManagerTest extends TestCase
 
         $filePath = $this->app['config']['langman.path'].'/en/users.php';
 
+        $this->expectException('\Illuminate\Contracts\Filesystem\FileNotFoundException');
         $manager->getFileContent($filePath);
     }
 
@@ -150,6 +188,26 @@ class ManagerTest extends TestCase
         $this->assertArrayHasKey('age', $enFile);
         $this->assertArrayNotHasKey('name', $nlFile);
         $this->assertArrayHasKey('age', $nlFile);
+    }
+
+    public function testRemoveTranslationLineFromJSONFiles()
+    {
+        $manager = $this->app[\Themsaid\Langman\Manager::class];
+
+        $this->createTempFiles([
+            'en' => ['-json' => ['String 1'=>'Trans 1', 'String 2'=>'Trans 2']],
+            'nl' => ['-json' => ['String 1'=>'Hola 1', 'String 2'=>'Hola 2']],
+        ]);
+
+        $manager->removeKey('-json', 'String 1');
+
+        $enFile = $manager->getFileContent($this->app['config']['langman.path'].'/en.json');
+        $nlFile = $manager->getFileContent($this->app['config']['langman.path'].'/nl.json');
+
+        $this->assertArrayNotHasKey('String 1', $enFile);
+        $this->assertArrayHasKey('String 2', $enFile);
+        $this->assertArrayNotHasKey('String 1', $nlFile);
+        $this->assertArrayHasKey('String 2', $nlFile);
     }
 
     public function testRemoveNestedTranslationLineFromAllFiles()
@@ -192,6 +250,24 @@ class ManagerTest extends TestCase
         $this->assertEquals('naam', $nlFile['name']);
     }
 
+    public function testFillJSONTranslationLinesThatDoesNotExistYet()
+    {
+        $manager = $this->app[\Themsaid\Langman\Manager::class];
+
+        $this->createTempFiles([
+            'en' => ['-json' => []],
+            'nl' => ['-json' => []],
+        ]);
+
+        $manager->fillKeys('-json', ['name' => ['en' => 'name', 'nl' => 'naam']]);
+
+        $enFile = $manager->getFileContent($this->app['config']['langman.path'].'/en.json');
+        $nlFile = $manager->getFileContent($this->app['config']['langman.path'].'/nl.json');
+
+        $this->assertEquals('name', $enFile['name']);
+        $this->assertEquals('naam', $nlFile['name']);
+    }
+
     public function testUpdatesTranslationLineThatExists()
     {
         $manager = $this->app[\Themsaid\Langman\Manager::class];
@@ -205,6 +281,27 @@ class ManagerTest extends TestCase
         $enFile = (array) include $this->app['config']['langman.path'].'/en/users.php';
 
         $this->assertEquals('name', $enFile['name']);
+    }
+
+    public function testUpdatesJSONTranslationLineThatExists()
+    {
+        $manager = $this->app[\Themsaid\Langman\Manager::class];
+
+        $enval = ['String 1'=>'Test 1', 'String 2'=>'Test 2'];
+        $nlval = ['String 1'=>'Hola 1', 'String 2'=>'Hola 2'];
+        $this->createTempFiles([
+            'en' => ['-json' => $enval],
+            'nl' => ['-json' => $nlval],
+        ]);
+
+        $manager->fillKeys('-json', ['String 1' => ['en' => 'name']]);
+
+        $enFile = $manager->getFileContent($this->app['config']['langman.path'].'/en.json');
+        $nlFile = $manager->getFileContent($this->app['config']['langman.path'].'/nl.json');
+
+        $enval['String 1']='name';
+        $this->assertEquals($enval, $enFile);
+        $this->assertEquals($nlval, $nlFile);
     }
 
     public function testFillNestedTranslationLines()
@@ -234,9 +331,37 @@ class ManagerTest extends TestCase
         array_map('rmdir', glob(__DIR__.'/views_temp/users'));
         array_map('unlink', glob(__DIR__.'/views_temp/users.blade.php'));
 
-        file_put_contents(__DIR__.'/views_temp/users.blade.php', '{{ trans(\'users.name\') }} {{ trans(\'users.age\') }}');
         mkdir(__DIR__.'/views_temp/users');
         file_put_contents(__DIR__.'/views_temp/users/index.blade.php', "{{ trans('users.city') }}");
+        file_put_contents(__DIR__.'/views_temp/user.blade.php', <<<HEREDOC
+// Translations cannot start at offset 0 in the file, the regex fails on that
+trans('user.name')
+trans('user.age')
+__('JSON string check')
+ trans_choice('user.choice1',12)
+ Lang::get('random json string')
+ Lang::choice('user.choice2','param')
+ Lang::trans('whatever')
+ Lang::transChoice('user.choice3','another')
+ @lang('do something')
+ @choice('user.choice4','old')
+
+Allow whitespace:
+trans     (     'user.ws'   
+   )
+
+Skip these
+->trans('not1')
+___('not2')
+@ lang('not3')
+@ choice('not4')
+trans(\$var)
+trans()
+anytrans('user.not5')
+trans ( 'user.not6' . \$additional )
+
+HEREDOC
+);
 
         $results = $manager->collectFromFiles();
 
@@ -244,10 +369,28 @@ class ManagerTest extends TestCase
         array_map('rmdir', glob(__DIR__.'/views_temp/users'));
         array_map('unlink', glob(__DIR__.'/views_temp/users.blade.php'));
 
-        $this->assertArrayHasKey('users', $results);
-        $this->assertContains('name', $results['users']);
-        $this->assertContains('age', $results['users']);
-        $this->assertContains('city', $results['users']);
+        $expected = [
+            "-json" => [
+                "JSON string check",
+                "random json string",
+                "whatever",
+                "do something",
+            ],
+            "user" => [
+                "name",
+                "age",
+                "choice1",
+                "choice2",
+                "choice3",
+                "choice4",
+                "ws"
+            ],
+            "users" => [
+                "city"
+            ]
+        ];
+
+        $this->assertEquals($expected, $results);
     }
 
     public function testGetKeysExistingInALanguageButNotTheOther()
@@ -261,11 +404,17 @@ class ManagerTest extends TestCase
             'user.nl.phone' => 'a',
             'user.en.address' => 'a',
             'user.nl.address' => 'a',
+            "-json.en.city" => 'city',
+            "-json.nl.handy" => 'phone'
         ]);
 
         $this->assertContains('user.name:nl', $results);
         $this->assertContains('user.phone:en', $results);
+        $this->assertContains('-json.city:nl', $results);
+        $this->assertContains('-json.handy:en', $results);
         $this->assertNotContains('user.address:en', $results);
         $this->assertNotContains('user.address:nl', $results);
+        $this->assertNotContains('-json.city:en', $results);
+        $this->assertNotContains('-json.handy:nl', $results);
     }
 }

--- a/tests/MissingCommandTest.php
+++ b/tests/MissingCommandTest.php
@@ -22,13 +22,13 @@ class MissingCommandTest extends TestCase
         ]);
 
         $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with(m::pattern('/user\.age:nl/'), NULL)->andReturn('fill_age');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.name:en/'), NULL)->andReturn('fill_name');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.color:nl/'), NULL)->andReturn('fill_color');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.size:nl/'), NULL)->andReturn('fill_size');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.id:nl/'), NULL)->andReturn('fill_missing_id');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.price:en/'), NULL)->andReturn('fill_missing_price');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.price:nl/'), NULL)->andReturn('fill_missing_price');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/user\.age:nl/'), null)->andReturn('fill_age');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.name:en/'), null)->andReturn('fill_name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.color:nl/'), null)->andReturn('fill_color');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.size:nl/'), null)->andReturn('fill_size');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.id:nl/'), null)->andReturn('fill_missing_id');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.price:en/'), null)->andReturn('fill_missing_price');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.price:nl/'), null)->andReturn('fill_missing_price');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:missing');
@@ -58,15 +58,15 @@ class MissingCommandTest extends TestCase
         ]);
 
         $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with(m::pattern('/String 1:nl/'), NULL)->andReturn('fill_age');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/String 2:nl/'), NULL)->andReturn('fill_name');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/String 3:en/'), NULL)->andReturn('fill_color');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/String 1:nl/'), null)->andReturn('fill_age');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/String 2:nl/'), null)->andReturn('fill_name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/String 3:en/'), null)->andReturn('fill_color');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:missing');
 
-        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
-        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), true);
+        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), true);
 
         $this->assertEquals('fill_age', $NLFile['String 1']);
         $this->assertEquals('fill_name', $NLFile['String 2']);

--- a/tests/MissingCommandTest.php
+++ b/tests/MissingCommandTest.php
@@ -22,13 +22,13 @@ class MissingCommandTest extends TestCase
         ]);
 
         $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with('/user\.age:nl/', null)->andReturn('fill_age');
-        $command->shouldReceive('ask')->once()->with('/product\.name:en/', null)->andReturn('fill_name');
-        $command->shouldReceive('ask')->once()->with('/product\.color:nl/', null)->andReturn('fill_color');
-        $command->shouldReceive('ask')->once()->with('/product\.size:nl/', null)->andReturn('fill_size');
-        $command->shouldReceive('ask')->once()->with('/missing\.missing\.id:nl/', null)->andReturn('fill_missing_id');
-        $command->shouldReceive('ask')->once()->with('/missing\.missing\.price:en/', null)->andReturn('fill_missing_price');
-        $command->shouldReceive('ask')->once()->with('/missing\.missing\.price:nl/', null)->andReturn('fill_missing_price');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/user\.age:nl/'), NULL)->andReturn('fill_age');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.name:en/'), NULL)->andReturn('fill_name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.color:nl/'), NULL)->andReturn('fill_color');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/product\.size:nl/'), NULL)->andReturn('fill_size');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.id:nl/'), NULL)->andReturn('fill_missing_id');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.price:en/'), NULL)->andReturn('fill_missing_price');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/missing\.missing\.price:nl/'), NULL)->andReturn('fill_missing_price');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:missing');
@@ -48,6 +48,31 @@ class MissingCommandTest extends TestCase
         $this->assertEquals('fill_missing_price', $missingENFile['missing']['price']);
     }
 
+    public function testCommandOutputJSON()
+    {
+        $manager = $this->app[Manager::class];
+
+        $this->createTempFiles([
+            'en' => [ '-json' => ['String 1'=>'String 1', 'String 2'=>'String 2']],
+            'nl' => [ '-json' => ['String 3'=>'Tiero']],
+        ]);
+
+        $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
+        $command->shouldReceive('ask')->once()->with(m::pattern('/String 1:nl/'), NULL)->andReturn('fill_age');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/String 2:nl/'), NULL)->andReturn('fill_name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/String 3:en/'), NULL)->andReturn('fill_color');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('langman:missing');
+
+        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
+        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+
+        $this->assertEquals('fill_age', $NLFile['String 1']);
+        $this->assertEquals('fill_name', $NLFile['String 2']);
+        $this->assertEquals('fill_color', $ENFile['String 3']);
+    }
+
     public function testAllowSeeTranslationInDefaultLanguage()
     {
         $manager = $this->app[Manager::class];
@@ -64,7 +89,7 @@ class MissingCommandTest extends TestCase
         ]);
 
         $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:nl<\/> translation/', '/en:Age/');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/<fg=yellow>user\.age:nl<\/> translation/'), 'en:Age');
 
         $this->app['artisan']->add($command);
 
@@ -87,7 +112,7 @@ class MissingCommandTest extends TestCase
         ]);
 
         $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:nl<\/> translation/', null);
+        $command->shouldReceive('ask')->once()->with(m::pattern('/<fg=yellow>user\.age:nl<\/> translation/'), null);
 
         $this->app['artisan']->add($command);
 

--- a/tests/RemoveCommandTest.php
+++ b/tests/RemoveCommandTest.php
@@ -46,8 +46,8 @@ class RemoveCommandTest extends TestCase
         $this->app['artisan']->add($command);
         $this->artisan('langman:remove', ['key' => 'String 1']);
 
-        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
-        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), true);
+        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), true);
 
         $this->assertArrayNotHasKey('String 1', $ENFile);
         $this->assertArrayNotHasKey('String 1', $NLFile);

--- a/tests/RemoveCommandTest.php
+++ b/tests/RemoveCommandTest.php
@@ -31,6 +31,28 @@ class RemoveCommandTest extends TestCase
         $this->assertArrayNotHasKey('name', $userNLFile);
     }
 
+    public function testCommandOutputJSON()
+    {
+        $manager = $this->app[Manager::class];
+
+        $this->createTempFiles([
+            'en' => [ '-json' => ['String 1'=>'String 1', 'String 2'=>'String 2']],
+            'nl' => [ '-json' => ['String 1'=>'Primo', 'String 2'=>'Secondo']],
+        ]);
+
+        $command = m::mock('\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
+        $command->shouldReceive('confirm')->once()->with('Are you sure you want to remove "String 1"?')->andReturn(true);
+
+        $this->app['artisan']->add($command);
+        $this->artisan('langman:remove', ['key' => 'String 1']);
+
+        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
+        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+
+        $this->assertArrayNotHasKey('String 1', $ENFile);
+        $this->assertArrayNotHasKey('String 1', $NLFile);
+    }
+
     public function testRemovesNestedKeys()
     {
         $manager = $this->app[Manager::class];

--- a/tests/RenameCommandTest.php
+++ b/tests/RenameCommandTest.php
@@ -42,8 +42,8 @@ class RenameCommandTest extends TestCase
 
         $this->artisan('langman:rename', ['oldKey' => 'String 1', 'newKey' => 'contact']);
 
-        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
-        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), true);
+        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), true);
 
         $this->assertArrayNotHasKey('String 1', $ENFile);
         $this->assertArrayNotHasKey('String 1', $NLFile);

--- a/tests/RenameCommandTest.php
+++ b/tests/RenameCommandTest.php
@@ -33,6 +33,24 @@ class RenameCommandTest extends TestCase
         $this->assertEquals($expectedValueES, $newValueES);
     }
 
+    public function testRenameAKeyValueForAllLanguagesJSON()
+    {
+        $this->createTempFiles([
+            'en' => [ '-json' => ['String 1'=>'String 1', 'String 2'=>'String 2']],
+            'nl' => [ '-json' => ['String 1'=>'Primo', 'String 2'=>'Secondo']],
+        ]);
+
+        $this->artisan('langman:rename', ['oldKey' => 'String 1', 'newKey' => 'contact']);
+
+        $ENFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
+        $NLFile = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+
+        $this->assertArrayNotHasKey('String 1', $ENFile);
+        $this->assertArrayNotHasKey('String 1', $NLFile);
+        $this->assertArrayHasKey('contact', $ENFile);
+        $this->assertArrayHasKey('contact', $NLFile);
+    }
+
     public function testRenameANestedKeyValueForAllLanguages()
     {
         $this->createTempFiles([
@@ -91,7 +109,7 @@ class RenameCommandTest extends TestCase
         array_map('rmdir', glob(__DIR__.'/views_temp/users'));
         array_map('unlink', glob(__DIR__.'/views_temp/users.blade.php'));
 
-        $this->assertContains("Renamed key was found in 2 file(s).", $this->consoleOutput());
+        $this->assertStringContainsString("Renamed key was found in 2 file(s).", $this->consoleOutput());
         $this->assertRegExp('/Encounters(?:.*)File/', $this->consoleOutput());
         $this->assertRegExp('/1(?:.*)users\.blade\.php/', $this->consoleOutput());
         $this->assertRegExp('/2(?:.*)users(\\\|\/)index\.blade\.php/', $this->consoleOutput());

--- a/tests/ShowCommandTest.php
+++ b/tests/ShowCommandTest.php
@@ -8,8 +8,141 @@ class ShowCommandTest extends TestCase
 
         $this->artisan('langman:show', ['key' => 'user']);
 
-        $this->assertContains('Language file user.php not found!', $this->consoleOutput());
+        $this->assertStringContainsString('JSON language strings not found!', $this->consoleOutput());
     }
+
+    public function testOptionCombination1()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user']);
+
+        $this->assertStringContainsString("Displaying specific keys matching 'user' from JSON strings using equality match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination2()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user', "--close"=>true]);
+
+        $this->assertStringContainsString("Displaying specific keys matching 'user' from JSON strings using substring match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination3()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user', "--close"=>true, "--unused"=>true]);
+
+        $this->assertStringContainsString("Displaying specific unused keys matching 'user' from JSON strings using substring match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination3b()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user', "--unused"=>true]);
+
+        $this->assertStringContainsString("Displaying specific unused keys matching 'user' from JSON strings using equality match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination4()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user.name']);
+
+        $this->assertStringContainsString("Displaying specific keys matching 'name' from user using equality match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination5()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user.name', "--close"=>true]);
+
+        $this->assertStringContainsString("Displaying specific keys matching 'name' from user using substring match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination6()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user.name', "--close"=>true, "--unused"=>true]);
+
+        $this->assertStringContainsString("Displaying specific unused keys matching 'name' from user using substring match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination6b()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => []]
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user.name', "--unused"=>true]);
+
+        $this->assertStringContainsString("Displaying specific unused keys matching 'name' from user using equality match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination7()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => [], 'user' => '<?php return []; ']
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user']);
+
+        $this->assertStringContainsString("Displaying all keys from user", $this->consoleOutput());
+    }
+
+    public function testOptionCombination8()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => [], 'user' => '<?php return []; ']
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user', '--close' => true]);
+
+        $this->assertStringContainsString("Displaying specific keys matching 'user' from JSON strings using substring match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination9()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => [], 'user' => '<?php return []; ']
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user', '--close' => true, '--unused' => true]);
+
+        $this->assertStringContainsString("Displaying specific unused keys matching 'user' from JSON strings using substring match", $this->consoleOutput());
+    }
+
+    public function testOptionCombination9b()
+    {
+        $this->createTempFiles([
+            "en" => ["-json" => [], 'user' => '<?php return []; ']
+        ]);
+
+        $this->artisan('langman:show', ['key' => 'user', '--unused' => true]);
+
+        $this->assertStringContainsString("Displaying all unused keys from user", $this->consoleOutput());
+    }
+
 
     public function testCommandOutputForFile()
     {
@@ -25,6 +158,20 @@ class ShowCommandTest extends TestCase
         $this->assertRegExp('/age(?:.*)Age(?:.*)|(?: *)|/', $this->consoleOutput());
     }
 
+    public function testCommandOutputForJSON()
+    {
+        $this->createTempFiles([
+            'en' => [ '-json' => ['String 1'=>'String 1', 'String 2'=>'String 2']],
+            'nl' => [ '-json' => ['String 1'=>'Primo', 'String 3 with a very long text that is cut off at some point' => 'Tiero']],
+        ]);
+
+        $this->artisan('langman:show');
+
+        $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
+        $this->assertRegExp('/String 1(?:.*)String 1(?:.*)Primo/', $this->consoleOutput());
+        $this->assertRegExp('/String 2(?:.*)String 2(?:.*)|(?: *)|/', $this->consoleOutput());
+        $this->assertRegExp('/String 3 with a very long text that is cut off at some point(?:.*)|(?: *)|(?:.*)Tiero/', $this->consoleOutput());
+    }
     public function testCommandOutputForFileAndSpecificLanguages()
     {
         $this->createTempFiles([
@@ -37,8 +184,8 @@ class ShowCommandTest extends TestCase
 
         $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
         $this->assertRegExp('/name(?:.*)Name(?:.*)Naam/', $this->consoleOutput());
-        $this->assertNotContains('Nome', $this->consoleOutput());
-        $this->assertNotContains('it_lang', $this->consoleOutput());
+        $this->assertStringNotContainsString('Nome', $this->consoleOutput());
+        $this->assertStringNotContainsString('it_lang', $this->consoleOutput());
     }
 
     public function testCommandOutputForPackageFile()
@@ -80,8 +227,8 @@ class ShowCommandTest extends TestCase
 
         $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
         $this->assertRegExp('/name(?:.*)Name(?:.*)Naam/', $this->consoleOutput());
-        $this->assertNotContains('age', $this->consoleOutput());
-        $this->assertNotContains('uname', $this->consoleOutput());
+        $this->assertStringNotContainsString('age', $this->consoleOutput());
+        $this->assertStringNotContainsString('uname', $this->consoleOutput());
     }
 
     public function testCommandOutputForNestedKey()
@@ -95,8 +242,8 @@ class ShowCommandTest extends TestCase
 
         $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
         $this->assertRegExp('/name.first(?:.*)first(?:.*)firstnl/', $this->consoleOutput());
-        $this->assertNotContains('name.last', $this->consoleOutput());
-        $this->assertNotContains('age', $this->consoleOutput());
+        $this->assertStringNotContainsString('name.last', $this->consoleOutput());
+        $this->assertStringNotContainsString('age', $this->consoleOutput());
     }
 
     public function testCommandOutputForSearchingParentKey()
@@ -111,7 +258,7 @@ class ShowCommandTest extends TestCase
         $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
         $this->assertRegExp('/name.first(?:.*)first(?:.*)firstnl/', $this->consoleOutput());
         $this->assertRegExp('/name.last(?:.*)last(?:.*)lastnl/', $this->consoleOutput());
-        $this->assertNotContains('age', $this->consoleOutput());
+        $this->assertStringNotContainsString('age', $this->consoleOutput());
     }
 
     public function testCommandOutputForKeyOnCloseMatch()
@@ -126,7 +273,7 @@ class ShowCommandTest extends TestCase
         $this->assertRegExp('/key(?:.*)en(?:.*)nl/', $this->consoleOutput());
         $this->assertRegExp('/name(?:.*)Name(?:.*)Naam/', $this->consoleOutput());
         $this->assertRegExp('/username(?:.*)uname(?:.*)|(?: *)|/', $this->consoleOutput());
-        $this->assertNotContains('age', $this->consoleOutput());
+        $this->assertStringNotContainsString('age', $this->consoleOutput());
     }
 
     public function test_ignore_attributes_and_keys_with_empty_arrays()

--- a/tests/SyncCommandTest.php
+++ b/tests/SyncCommandTest.php
@@ -8,30 +8,104 @@ class SyncCommandTest extends TestCase
         array_map('rmdir', glob(__DIR__.'/views_temp/user'));
         array_map('unlink', glob(__DIR__.'/views_temp/user.blade.php'));
 
-        file_put_contents(__DIR__.'/views_temp/user.blade.php', '{{ trans(\'user.name\') }} {{ trans(\'user.age\') }}');
+        file_put_contents(__DIR__.'/views_temp/user.blade.php', <<<HEREDOC
+// Translations cannot start at offset 0 in the file, the regex fails on that
+trans('user.name')
+trans('user.age')
+__('JSON string check')
+ trans_choice('user.choice1',12)
+ Lang::get('random json string')
+ Lang::choice('user.choice2','param')
+ Lang::trans('whatever')
+ Lang::transChoice('user.choice3','another')
+ @lang('do something')
+ @choice('user.choice4','old')
+
+Allow whitespace:
+trans     (     'user.ws'   
+   )
+
+Skip these
+->trans('not1')
+___('not2')
+@ lang('not3')
+@ choice('not4')
+trans(\$var)
+trans()
+anytrans('user.not5')
+trans ( 'user.not6' . \$additional )
+
+HEREDOC
+);
         mkdir(__DIR__.'/views_temp/user');
         file_put_contents(__DIR__.'/views_temp/user/index.blade.php', "{{ trans('user.city') }} {{ trans('user.code.initial') }}");
 
         $this->createTempFiles([
-            'en' => ['user' => "<?php\n return ['name' => 'Name', 'not_in_files' => 'a'];"],
-            'nl' => ['user' => "<?php\n return [];"],
+            'en' => [
+                'user' => "<?php\n return ['name' => 'Name', 'not_in_files' => 'a'];",
+                '-json' => ['whatever'=>'Sailor', 'json_en'=>'JSON' ]
+            ],
+            'nl' => [
+                'user' => "<?php\n return ['only_in_nl'=>'ja'];",
+                '-json' => ['whatever'=>'Matroos', 'json_nl'=>'my_json' ]
+            ],
         ]);
 
         $this->artisan('langman:sync');
 
         $userENFile = (array) include $this->app['config']['langman.path'].'/en/user.php';
         $userNlFile = (array) include $this->app['config']['langman.path'].'/nl/user.php';
+        $userJSONFileEN = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
+        $userJSONFileNL = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
 
-        $this->assertArrayHasKey('name', $userENFile);
-        $this->assertArrayHasKey('not_in_files', $userENFile);
-        $this->assertArrayHasKey('initial', $userENFile['code']);
-        $this->assertArrayHasKey('age', $userENFile);
-        $this->assertArrayHasKey('city', $userENFile);
-        $this->assertArrayHasKey('name', $userNlFile);
-        $this->assertArrayHasKey('not_in_files', $userNlFile);
-        $this->assertArrayHasKey('initial', $userNlFile['code']);
-        $this->assertArrayHasKey('age', $userNlFile);
-        $this->assertArrayHasKey('city', $userNlFile);
+        $expectedEN=[
+            'name' => 'Name',
+            'not_in_files' => 'a',
+            'code' => ['initial' => ''],
+            'age' => '',
+            'city' => '',
+            'choice1' => '',
+            'choice2' => '',
+            'choice3' => '',
+            'choice4' => '',
+            'ws' => '',
+            'only_in_nl' => ''
+        ];
+        $expectedENJson = [
+            'JSON string check' => '',
+            'random json string' => '',
+            'whatever' => 'Sailor',
+            'do something' => '',
+            'json_nl' => '',
+            'json_en' => 'JSON'
+        ];
+
+        $expectedNL=[
+            'name' => '',
+            'not_in_files' => '',
+            'code' => ['initial' => ''],
+            'age' => '',
+            'city' => '',
+            'choice1' => '',
+            'choice2' => '',
+            'choice3' => '',
+            'choice4' => '',
+            'ws' => '',
+            'only_in_nl'=> 'ja'
+        ];
+        $expectedNLJson = [
+            'JSON string check' => '',
+            'random json string' => '',
+            'whatever' => 'Matroos',
+            'do something' => '',
+            'json_nl' => 'my_json',
+            'json_en' => ''
+        ];
+
+        $this->assertEquals($expectedEN, $userENFile);
+        $this->assertEquals($expectedENJson, $userJSONFileEN);
+        $this->assertEquals($expectedNL, $userNlFile);
+        $this->assertEquals($expectedNLJson, $userJSONFileNL);
 
         array_map('unlink', glob(__DIR__.'/views_temp/user/index.blade.php'));
         array_map('rmdir', glob(__DIR__.'/views_temp/user'));
@@ -50,7 +124,7 @@ class SyncCommandTest extends TestCase
 
         $this->createTempFiles([
             'en' => ['user' => "<?php\n return ['name' => ['middle' => 'middle', 'first' => 'old_value','not_in_files' => 'a']];"],
-            'nl' => ['user' => "<?php\n return ['name' => ['middle' => 'middle', 'first' => 'old_value']];"],
+            'nl' => ['user' => "<?php\n return ['name' => ['middle' => 'middle2', 'first' => 'old_value2']];"],
         ]);
 
         $this->artisan('langman:sync');
@@ -58,12 +132,14 @@ class SyncCommandTest extends TestCase
         $userENFile = (array) include $this->app['config']['langman.path'].'/en/user.php';
         $userNLFile = (array) include $this->app['config']['langman.path'].'/nl/user.php';
 
-        $this->assertArrayHasKey('not_in_files', $userNLFile['name']);
-        $this->assertArrayHasKey('name', $userENFile);
-        $this->assertArrayHasKey('first', $userENFile['name']);
-        $this->assertEquals('old_value', $userENFile['name']['first']);
-        $this->assertArrayHasKey('last', $userENFile['name']);
-        $this->assertArrayHasKey('middle', $userENFile['name']);
+        $expectEN = [
+            'name' => ['middle' => 'middle', 'first' => 'old_value', 'last' => '', 'not_in_files' => 'a' ]
+        ];
+        $expectNL = [
+            'name' => ['middle' => 'middle2', 'first' => 'old_value2', 'last'=> '', 'not_in_files' => '' ]
+        ];
+        $this->assertEquals($expectEN, $userENFile);
+        $this->assertEquals($expectNL, $userNLFile);
 
         array_map('unlink', glob(__DIR__.'/views_temp/user/index.blade.php'));
         array_map('rmdir', glob(__DIR__.'/views_temp/user'));

--- a/tests/SyncCommandTest.php
+++ b/tests/SyncCommandTest.php
@@ -55,8 +55,8 @@ HEREDOC
 
         $userENFile = (array) include $this->app['config']['langman.path'].'/en/user.php';
         $userNlFile = (array) include $this->app['config']['langman.path'].'/nl/user.php';
-        $userJSONFileEN = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), TRUE);
-        $userJSONFileNL = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), TRUE);
+        $userJSONFileEN = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), true);
+        $userJSONFileNL = (array) json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), true);
 
         $expectedEN=[
             'name' => 'Name',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,18 +15,20 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
         $app['config']->set('view.paths', [__DIR__.'/views_temp']);
     }
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
+        $this->withoutMockingConsoleOutput();
 
         exec('rm -rf '.__DIR__.'/temp/*');
+        exec('rm -rf '.__DIR__.'/views_temp/*');
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         parent::tearDown();
 
-        exec('rm -rf '.__DIR__.'/temp/*');
+        exec('rm -rf '.__DIR__.'/views_temp/*');
 
         $this->consoleOutput = '';
     }
@@ -37,7 +39,7 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
             mkdir(__DIR__.'/temp/'.$dir);
 
             foreach ($dirFiles as $file => $content) {
-                if (is_array($content)) {
+                if (is_array($content) && $file!== "-json") {
                     mkdir(__DIR__.'/temp/'.$dir.'/'.$file);
 
                     foreach ($content as $subDir => $subContent) {
@@ -47,7 +49,12 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
                         }
                     }
                 } else {
-                    file_put_contents(__DIR__.'/temp/'.$dir.'/'.$file.'.php', $content);
+                    if($file == "-json") {
+                        file_put_contents(__DIR__.'/temp/'.$dir.'.json', json_encode($content, JSON_PRETTY_PRINT));
+                    }
+                    else {
+                        file_put_contents(__DIR__.'/temp/'.$dir.'/'.$file.'.php', $content);
+                    }
                 }
             }
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,10 +49,9 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
                         }
                     }
                 } else {
-                    if($file == "-json") {
+                    if ($file == "-json") {
                         file_put_contents(__DIR__.'/temp/'.$dir.'.json', json_encode($content, JSON_PRETTY_PRINT));
-                    }
-                    else {
+                    } else {
                         file_put_contents(__DIR__.'/temp/'.$dir.'/'.$file.'.php', $content);
                     }
                 }

--- a/tests/TransCommandTest.php
+++ b/tests/TransCommandTest.php
@@ -14,16 +14,16 @@ class TransCommandTest extends TestCase
 
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with(m::pattern('/users:en/'), NULL)->andReturn('test');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/users:nl/'), NULL)->andReturn('otherwise');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users:en/'), null)->andReturn('test');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users:nl/'), null)->andReturn('otherwise');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users']);
 
-        $ENFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'),TRUE);
-        $NLFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'),TRUE);
-        $this->assertEquals(["admin"=>"Admini","users"=>"otherwise"],$NLFile);
-        $this->assertEquals(["admin"=>"Admin","users"=>"test"],$ENFile);
+        $ENFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'),true);
+        $NLFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'),true);
+        $this->assertEquals(["admin" => "Admini","users" => "otherwise"], $NLFile);
+        $this->assertEquals(["admin" => "Admin","users" => "test"], $ENFile);
     }
 
     public function testCommandErrorOutputOnLanguageNotFound()
@@ -100,8 +100,8 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), NULL)->andReturn('name');
-        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:nl/'), NULL)->andReturn('naam');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), null)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:nl/'), null)->andReturn('naam');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name']);
@@ -164,7 +164,7 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), NULL)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), null)->andReturn('name');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name', '--lang' => 'en']);

--- a/tests/TransCommandTest.php
+++ b/tests/TransCommandTest.php
@@ -5,13 +5,25 @@ use Themsaid\Langman\Manager;
 
 class TransCommandTest extends TestCase
 {
-    public function testCommandErrorOutputOnMissingKey()
+    public function testCommandOutputOnJSONKey()
     {
-        $this->createTempFiles();
+        $this->createTempFiles([
+            'en' => [ "-json" => ["admin" => 'Admin'] ],
+            'nl' => [ "-json" => ["admin" => 'Admini'] ],
+        ]);
 
+        $manager = $this->app[Manager::class];
+        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users:en/'), NULL)->andReturn('test');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users:nl/'), NULL)->andReturn('otherwise');
+
+        $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users']);
 
-        $this->assertContains('Could not recognize the key you want to translate.', $this->consoleOutput());
+        $ENFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'),TRUE);
+        $NLFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'),TRUE);
+        $this->assertEquals(["admin"=>"Admini","users"=>"otherwise"],$NLFile);
+        $this->assertEquals(["admin"=>"Admin","users"=>"test"],$ENFile);
     }
 
     public function testCommandErrorOutputOnLanguageNotFound()
@@ -20,7 +32,7 @@ class TransCommandTest extends TestCase
 
         $this->artisan('langman:trans', ['key' => 'users.name', '--lang' => 'sd']);
 
-        $this->assertContains('Language (sd) could not be found!', $this->consoleOutput());
+        $this->assertStringContainsString('Language (sd) could not be found!', $this->consoleOutput());
     }
 
     public function testCommandAsksForConfirmationToCreateFileIfNotFound()
@@ -88,8 +100,8 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with('/users\.name:en/', null)->andReturn('name');
-        $command->shouldReceive('ask')->once()->with('/users\.name:nl/', null)->andReturn('naam');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), NULL)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:nl/'), NULL)->andReturn('naam');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name']);
@@ -108,8 +120,8 @@ class TransCommandTest extends TestCase
 
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
-        $command->shouldReceive('ask')->once()->with('/users\.name:en/', null)->andReturn('name');
-        $command->shouldReceive('ask')->once()->with('/users\.name:sp/', null)->andReturn('naam');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), null)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:sp/'), null)->andReturn('naam');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'package::users.name']);
@@ -130,8 +142,8 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with('/users\.name:en/', 'nil')->andReturn('name');
-        $command->shouldReceive('ask')->once()->with('/users\.name:nl/', '')->andReturn('naam');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), 'nil')->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:nl/'), '')->andReturn('naam');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name']);
@@ -152,7 +164,7 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with('/users\.name:en/', null)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name:en/'), NULL)->andReturn('name');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name', '--lang' => 'en']);
@@ -171,8 +183,8 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with('/users\.name\.first:en/', null)->andReturn('name');
-        $command->shouldReceive('ask')->once()->with('/users\.name\.first:nl/', null)->andReturn('naam');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name\.first:en/'), null)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name\.first:nl/'), null)->andReturn('naam');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name.first']);
@@ -193,7 +205,7 @@ class TransCommandTest extends TestCase
         $manager = $this->app[Manager::class];
         $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
-        $command->shouldReceive('ask')->once()->with('/users\.name\.first:en/', null)->andReturn('name');
+        $command->shouldReceive('ask')->once()->with(m::pattern('/users\.name\.first:en/'), null)->andReturn('name');
 
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users.name.first', '--lang' => 'en']);

--- a/tests/TransCommandTest.php
+++ b/tests/TransCommandTest.php
@@ -20,8 +20,8 @@ class TransCommandTest extends TestCase
         $this->app['artisan']->add($command);
         $this->artisan('langman:trans', ['key' => 'users']);
 
-        $ENFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'),true);
-        $NLFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'),true);
+        $ENFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/en.json'), true);
+        $NLFile = json_decode(file_get_contents($this->app['config']['langman.path'].'/nl.json'), true);
         $this->assertEquals(["admin" => "Admini","users" => "otherwise"], $NLFile);
         $this->assertEquals(["admin" => "Admin","users" => "test"], $ENFile);
     }


### PR DESCRIPTION
Added support for Laravel 7 (and 6).
Adjusted the Test cases to support changes in PHPUnit 8 and PHPUnit 9, which is shipped with Laravel 7.
Added support for JSON translation strings.
Added --unused flag to the Show command to allow finding translation keys that are not used anywhere in your project.
Updates unit tests, adjusted the Readme accordingly.