### PR TITLE
Add Support for PHP 7.4

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -110,9 +110,9 @@ class FindCommand extends Command
 
             foreach ($allLanguages as $languageKey) {
                 $original[$languageKey] =
-                    isset($values[$languageKey])
+                    (isset($values[$languageKey])
                         ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                        : isset($filesContent[$fileName][$languageKey][$key])) ? $filesContent[$fileName][$languageKey][$key] : '';
             }
 
             // Sort the language values based on language name


### PR DESCRIPTION
PHP 7.4 ternary operations works differently (ie. more explicit) with brackets.