### PR TITLE
Issue Fixed  Unparenthesized deprecated

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -109,10 +109,12 @@ class FindCommand extends Command
             $original = [];
 
             foreach ($allLanguages as $languageKey) {
-                $original[$languageKey] =
-                    isset($values[$languageKey])
-                        ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                $original[$languageKey] = 
+                    (isset($values[$languageKey])) 
+                        ? ($values[$languageKey]) 
+                        : ((isset($filesContent[$fileName][$languageKey][$key])) 
+                            ? ($filesContent[$fileName][$languageKey][$key]) 
+                            : '');
             }
 
             // Sort the language values based on language name


### PR DESCRIPTION
Following Issue is Fixed!
 
ErrorException  : Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`

 Illuminate\Foundation\Bootstrap\HandleExceptions::handleError("Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`", "I:\
xampp\htdocs\gigxlife-web\vendor\themsaid\laravel-langman\src\Commands\FindCommand.php", ["I:\xampp\htdocs\my_project\vendor\composer/../themsaid/laravel-langman/src/Commands/FindCom
mand.php"])