### PR TITLE
Fix: Deprecated Unparenthesized a ? b : c ? d : e`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ $ composer require themsaid/laravel-langman
 Once done, add the following line in your providers array of `config/app.php`:
 
 ```php
-Themsaid\Langman\LangmanServiceProvider::class
+Muathye\Themsaid\Langman\LangmanServiceProvider::class
 ```
 
 This package has a single configuration option that points to the `resources/lang` directory, if only you need to change
 the path then publish the config file:
 
 ```
-php artisan vendor:publish --provider="Themsaid\Langman\LangmanServiceProvider"
+php artisan vendor:publish --provider="Muathye\Themsaid\Langman\LangmanServiceProvider"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <h1 align="center">Laravel Langman</h1>
 
+
+<p align="center">
+This is a fork of https://github.com/themsaid/laravel-langman and its needed in my project, but because of its not maintained any more and after I pulled request to fix an issue I re-namespace this package to use it in my projects
+</p>
 <p align="center">
 Langman is a language files manager in your artisan console, it helps you search, update, add, and remove
 translation lines with ease. Taking care of a multilingual interface is not a headache anymore.

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,18 @@
 {
-    "name": "themsaid/laravel-langman",
+    "name": "muath-ye/laravel-langman",
     "description": "Manage language files with ease.",
     "keywords": ["laravel", "localization", "multilingual"],
-    "homepage": "https://github.com/themsaid/laravel-langman",
+    "homepage": "https://github.com/muath-ye/laravel-langman",
     "license": "MIT",
     "authors": [
         {
             "name": "Mohamed Said",
             "email": "theMohamedSaid@gmail.com",
             "homepage": "https://themsaid.github.io"
+        },
+        {
+            "name": "Muath Assawadi",
+            "homepage": "https://muath-ye.github.io"
         }
     ],
     "require": {
@@ -25,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Themsaid\\Langman\\": "src"
+            "Muathye\\Themsaid\\Langman\\": "src"
         },
         "classmap": [
             "tests"
@@ -34,7 +38,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Themsaid\\Langman\\LangmanServiceProvider"
+                "Muathye\\Themsaid\\Langman\\LangmanServiceProvider"
             ]
         }
     }

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -110,9 +110,9 @@ class FindCommand extends Command
 
             foreach ($allLanguages as $languageKey) {
                 $original[$languageKey] =
-                    isset($values[$languageKey])
-                        ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                isset($values[$languageKey])
+                    ? ($values[$languageKey])
+                    : ((isset($filesContent[$fileName][$languageKey][$key])) ? ($filesContent[$fileName][$languageKey][$key]) : (''));
             }
 
             // Sort the language values based on language name

--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 use Illuminate\Support\Str;
 
 class FindCommand extends Command
@@ -26,7 +26,7 @@ class FindCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
@@ -40,7 +40,7 @@ class FindCommand extends Command
     /**
      * ListCommand constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      * @return void
      */
     public function __construct(Manager $manager)

--- a/src/Commands/MissingCommand.php
+++ b/src/Commands/MissingCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class MissingCommand extends Command
 {
@@ -25,7 +25,7 @@ class MissingCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
@@ -39,7 +39,7 @@ class MissingCommand extends Command
     /**
      * ListCommand constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      * @return void
      */
     public function __construct(Manager $manager)

--- a/src/Commands/RemoveCommand.php
+++ b/src/Commands/RemoveCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class RemoveCommand extends Command
 {
@@ -25,7 +25,7 @@ class RemoveCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
@@ -39,7 +39,7 @@ class RemoveCommand extends Command
     /**
      * ListCommand constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      * @return void
      */
     public function __construct(Manager $manager)

--- a/src/Commands/RenameCommand.php
+++ b/src/Commands/RenameCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class RenameCommand extends Command
 {
@@ -26,7 +26,7 @@ class RenameCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
@@ -40,7 +40,7 @@ class RenameCommand extends Command
     /**
      * ListCommand constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      * @return void
      */
     public function __construct(Manager $manager)

--- a/src/Commands/ShowCommand.php
+++ b/src/Commands/ShowCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class ShowCommand extends Command
 {
@@ -27,7 +27,7 @@ class ShowCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
@@ -62,7 +62,7 @@ class ShowCommand extends Command
     /**
      * ListCommand constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      */
     public function __construct(Manager $manager)
     {

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class SyncCommand extends Command
 {
@@ -25,14 +25,14 @@ class SyncCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
     /**
      * Command constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      * @return void
      */
     public function __construct(Manager $manager)

--- a/src/Commands/TransCommand.php
+++ b/src/Commands/TransCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Themsaid\Langman\Commands;
+namespace Muathye\Themsaid\Langman\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class TransCommand extends Command
 {
@@ -53,7 +53,7 @@ class TransCommand extends Command
     /**
      * The Languages manager instance.
      *
-     * @var \Themsaid\LangMan\Manager
+     * @var \Muathye\Themsaid\Langman\Manager
      */
     private $manager;
 
@@ -67,7 +67,7 @@ class TransCommand extends Command
     /**
      * ListCommand constructor.
      *
-     * @param \Themsaid\LangMan\Manager $manager
+     * @param \Muathye\Themsaid\Langman\Manager $manager
      * @return void
      */
     public function __construct(Manager $manager)

--- a/src/LangmanServiceProvider.php
+++ b/src/LangmanServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Themsaid\Langman;
+namespace Muathye\Themsaid\Langman;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Filesystem\Filesystem;
@@ -30,13 +30,13 @@ class LangmanServiceProvider extends ServiceProvider
         });
 
         $this->commands([
-            \Themsaid\Langman\Commands\MissingCommand::class,
-            \Themsaid\Langman\Commands\RemoveCommand::class,
-            \Themsaid\Langman\Commands\TransCommand::class,
-            \Themsaid\Langman\Commands\ShowCommand::class,
-            \Themsaid\Langman\Commands\FindCommand::class,
-            \Themsaid\Langman\Commands\SyncCommand::class,
-            \Themsaid\Langman\Commands\RenameCommand::class,
+            \Muathye\Themsaid\Langman\Commands\MissingCommand::class,
+            \Muathye\Themsaid\Langman\Commands\RemoveCommand::class,
+            \Muathye\Themsaid\Langman\Commands\TransCommand::class,
+            \Muathye\Themsaid\Langman\Commands\ShowCommand::class,
+            \Muathye\Themsaid\Langman\Commands\FindCommand::class,
+            \Muathye\Themsaid\Langman\Commands\SyncCommand::class,
+            \Muathye\Themsaid\Langman\Commands\RenameCommand::class,
         ]);
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Themsaid\Langman;
+namespace Muathye\Themsaid\Langman;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -7,7 +7,7 @@ class ManagerTest extends TestCase
 {
     public function testFilesMethod()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['user' => '', 'category' => ''],
@@ -40,7 +40,7 @@ class ManagerTest extends TestCase
 
     public function testLanguagesMethod()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => [],
@@ -53,7 +53,7 @@ class ManagerTest extends TestCase
 
     public function testCreateFileIfNotExisting()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => [],
@@ -71,7 +71,7 @@ class ManagerTest extends TestCase
 
     public function testWriteFile()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => ''],
@@ -94,7 +94,7 @@ class ManagerTest extends TestCase
 
     public function testGetFileContentReadsContent()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => "<?php return ['_content_'];"],
@@ -110,7 +110,7 @@ class ManagerTest extends TestCase
      */
     public function testGetFileContentThrowsExceptionIfNotFound()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles();
 
@@ -121,7 +121,7 @@ class ManagerTest extends TestCase
 
     public function testGetFileContentCreatesFileIfNeeded()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles();
 
@@ -134,7 +134,7 @@ class ManagerTest extends TestCase
 
     public function testRemoveTranslationLineFromAllFiles()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => "<?php return ['name'=> 'a', 'age' => 'b'];"],
@@ -154,7 +154,7 @@ class ManagerTest extends TestCase
 
     public function testRemoveNestedTranslationLineFromAllFiles()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => "<?php return ['name'=> ['f' => '1', 's' => 2], 'age' => 'b'];"],
@@ -176,7 +176,7 @@ class ManagerTest extends TestCase
 
     public function testFillTranslationLinesThatDoesNotExistYet()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => '<?php return [];'],
@@ -194,7 +194,7 @@ class ManagerTest extends TestCase
 
     public function testUpdatesTranslationLineThatExists()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => "<?php return ['name' => 'nil'];"],
@@ -209,7 +209,7 @@ class ManagerTest extends TestCase
 
     public function testFillNestedTranslationLines()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => '<?php return ["class" => "class"];'],
@@ -228,7 +228,7 @@ class ManagerTest extends TestCase
 
     public function testFindTranslationsInProjectFiles()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         array_map('unlink', glob(__DIR__.'/views_temp/users/index.blade.php'));
         array_map('rmdir', glob(__DIR__.'/views_temp/users'));
@@ -252,7 +252,7 @@ class ManagerTest extends TestCase
 
     public function testGetKeysExistingInALanguageButNotTheOther()
     {
-        $manager = m::mock('Themsaid\Langman\Manager[languages]', [new Filesystem(), '', []]);
+        $manager = m::mock('Muathye\Themsaid\Langman\Manager[languages]', [new Filesystem(), '', []]);
 
         $manager->shouldReceive('languages')->andReturn(['en', 'nl']);
 

--- a/tests/MissingCommandTest.php
+++ b/tests/MissingCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 use Mockery as m;
 
 class MissingCommandTest extends TestCase
@@ -21,7 +21,7 @@ class MissingCommandTest extends TestCase
             ],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
         $command->shouldReceive('ask')->once()->with('/user\.age:nl/', null)->andReturn('fill_age');
         $command->shouldReceive('ask')->once()->with('/product\.name:en/', null)->andReturn('fill_name');
         $command->shouldReceive('ask')->once()->with('/product\.color:nl/', null)->andReturn('fill_color');
@@ -63,7 +63,7 @@ class MissingCommandTest extends TestCase
             ],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
         $command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:nl<\/> translation/', '/en:Age/');
 
         $this->app['artisan']->add($command);
@@ -86,7 +86,7 @@ class MissingCommandTest extends TestCase
             ],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\MissingCommand[ask]', [$manager]);
         $command->shouldReceive('ask')->once()->with('/<fg=yellow>user\.age:nl<\/> translation/', null);
 
         $this->app['artisan']->add($command);

--- a/tests/RemoveCommandTest.php
+++ b/tests/RemoveCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 use Mockery as m;
 
 class RemoveCommandTest extends TestCase
@@ -18,7 +18,7 @@ class RemoveCommandTest extends TestCase
             ],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->with('Are you sure you want to remove "user.name"?')->andReturn(true);
 
         $this->app['artisan']->add($command);
@@ -44,7 +44,7 @@ class RemoveCommandTest extends TestCase
             ],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->andReturn(true);
 
         $this->app['artisan']->add($command);
@@ -72,7 +72,7 @@ class RemoveCommandTest extends TestCase
             ],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->andReturn(true);
 
         $this->app['artisan']->add($command);
@@ -95,7 +95,7 @@ class RemoveCommandTest extends TestCase
             'vendor' => ['package' => ['en' => ['file' => "<?php\n return ['not_found' => 'file not found here'];"], 'sp' => ['file' => "<?php\n return ['not_found' => 'something'];"]]],
         ]);
 
-        $command = m::mock('\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\RemoveCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->with('Are you sure you want to remove "package::file.not_found"?')->andReturn(true);
 
         $this->app['artisan']->add($command);

--- a/tests/RenameCommandTest.php
+++ b/tests/RenameCommandTest.php
@@ -71,7 +71,7 @@ class RenameCommandTest extends TestCase
 
     public function testRenameCommandShowViewFilesAffectedForTheChange()
     {
-        $manager = $this->app[\Themsaid\Langman\Manager::class];
+        $manager = $this->app[\Muathye\Themsaid\Langman\Manager::class];
 
         $this->createTempFiles([
             'en' => ['users' => "<?php\n return['name' => 'Name'];"],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ abstract class TestCase extends Orchestra\Testbench\TestCase
 
     protected function getPackageProviders($app)
     {
-        return [\Themsaid\Langman\LangmanServiceProvider::class];
+        return [\Muathye\Themsaid\Langman\LangmanServiceProvider::class];
     }
 
     protected function getEnvironmentSetUp($app)

--- a/tests/TransCommandTest.php
+++ b/tests/TransCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Mockery as m;
-use Themsaid\Langman\Manager;
+use Muathye\Themsaid\Langman\Manager;
 
 class TransCommandTest extends TestCase
 {
@@ -27,7 +27,7 @@ class TransCommandTest extends TestCase
     {
         $this->createTempFiles();
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->andReturn(false);
 
         $this->app['artisan']->add($command);
@@ -41,7 +41,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->andReturn(true);
 
         $this->app['artisan']->add($command);
@@ -55,7 +55,7 @@ class TransCommandTest extends TestCase
         $this->createTempFiles(['en' => []]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->andReturn(false);
 
         $this->app['artisan']->add($command);
@@ -69,7 +69,7 @@ class TransCommandTest extends TestCase
         $this->createTempFiles(['en' => []]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[confirm]', [$manager]);
         $command->shouldReceive('confirm')->once()->andReturn(true);
 
         $this->app['artisan']->add($command);
@@ -86,7 +86,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
         $command->shouldReceive('ask')->once()->with('/users\.name:en/', null)->andReturn('name');
         $command->shouldReceive('ask')->once()->with('/users\.name:nl/', null)->andReturn('naam');
@@ -107,7 +107,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('ask')->once()->with('/users\.name:en/', null)->andReturn('name');
         $command->shouldReceive('ask')->once()->with('/users\.name:sp/', null)->andReturn('naam');
 
@@ -128,7 +128,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
         $command->shouldReceive('ask')->once()->with('/users\.name:en/', 'nil')->andReturn('name');
         $command->shouldReceive('ask')->once()->with('/users\.name:nl/', '')->andReturn('naam');
@@ -150,7 +150,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
         $command->shouldReceive('ask')->once()->with('/users\.name:en/', null)->andReturn('name');
 
@@ -169,7 +169,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
         $command->shouldReceive('ask')->once()->with('/users\.name\.first:en/', null)->andReturn('name');
         $command->shouldReceive('ask')->once()->with('/users\.name\.first:nl/', null)->andReturn('naam');
@@ -191,7 +191,7 @@ class TransCommandTest extends TestCase
         ]);
 
         $manager = $this->app[Manager::class];
-        $command = m::mock('\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
+        $command = m::mock('\Muathye\Themsaid\Langman\Commands\TransCommand[ask]', [$manager]);
         $command->shouldReceive('confirm')->never();
         $command->shouldReceive('ask')->once()->with('/users\.name\.first:en/', null)->andReturn('name');
 


### PR DESCRIPTION
I found the issue when executing ```composer install```

@php artisan package:discover

   ErrorException  : Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`

  at A:\_WebDev\_Projects\aymen-requests\laravel_application\vendor\themsaid\laravel-langman\src\Commands\FindCommand.php:113
    109|             $original = [];
    110|
    111|             foreach ($allLanguages as $languageKey) {
    112|                 $original[$languageKey] =
  > 113|                     isset($values[$languageKey])
    114|                         ? $values[$languageKey]
    115|                         : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
    116|             }
    117|

  Exception trace:

  1   Illuminate\Foundation\Bootstrap\HandleExceptions::handleError("Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`", "A:\_WebDev\_Projects\aymen-requests\laravel_application\vendor\themsaid\laravel-langman\src\Commands\FindCommand.php", ["A:\_WebDev\_Projects\aymen-requests\laravel_application\vendor\composer/../themsaid/laravel-langman/src/Commands/FindCommand.php"])
      A:\_WebDev\_Projects\aymen-requests\laravel_application\vendor\composer\ClassLoader.php:444

  2   include()
      A:\_WebDev\_Projects\aymen-requests\laravel_application\vendor\composer\ClassLoader.php:444

  Please use the argument -v to see more details.
Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1

And it solved as this ```stackoverflow``` answer:
> https://stackoverflow.com/questions/61432488/php-error-unparenthesized-a-b-c-d-e-is-deprecated-use-either-a