### PR TITLE
Fix Unparenthesized ternary inside ternary

### DIFF
--- a/src/Commands/FindCommand.php
+++ b/src/Commands/FindCommand.php
@@ -112,7 +112,7 @@ class FindCommand extends Command
                 $original[$languageKey] =
                     isset($values[$languageKey])
                         ? $values[$languageKey]
-                        : isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '';
+                        : (isset($filesContent[$fileName][$languageKey][$key]) ? $filesContent[$fileName][$languageKey][$key] : '');
             }
 
             // Sort the language values based on language name


### PR DESCRIPTION
Fixing ErrorException : Unparenthesized a ? b : c ? d : e is deprecated. Use either (a ? b : c) ? d : e or a ? b : (c ? d : e)

On PHP >= 7.4 this was generating an Exception on my composer install.

Thanks in advance!